### PR TITLE
feat: add keplr button

### DIFF
--- a/docs/reference/wallets.mdx
+++ b/docs/reference/wallets.mdx
@@ -7,6 +7,7 @@ sidebar_position: 4
 ---
 
 import { AddressConverter } from "@site/src/components/AddressConverter/AddressConverter";
+import Keplr from "@site/src/components/Keplr/Keplr";
 
 # Overview
 
@@ -35,6 +36,15 @@ We suggest using the following for testing Bitcoin transactions (although there
 are alternatives if you prefer other wallets!):
 
 - [XDEFI Wallet](https://xdefi.io)
+
+## Cosmos Wallets
+
+### Keplr Wallet
+
+Keplr is a popular extension and mobile wallet for Cosmos-based chains. It can
+be used to interact with ZetaChain. Learn more about Keplr: https://keplr.app/
+
+<Keplr />
 
 ## Address converter
 

--- a/src/components/Keplr/Keplr.tsx
+++ b/src/components/Keplr/Keplr.tsx
@@ -91,9 +91,6 @@ export const Keplr: React.FC<{}> = () => {
         checkChain();
       } catch (error) {
         console.error("Error suggesting chain:", error);
-        setChainStatusMessage(
-          "Failed to suggest ZetaChain to Keplr extension."
-        );
       }
     } else {
       checkChain();

--- a/src/components/Keplr/Keplr.tsx
+++ b/src/components/Keplr/Keplr.tsx
@@ -1,0 +1,118 @@
+import React, { useEffect, useState, useCallback } from "react";
+
+export const Keplr: React.FC<{}> = () => {
+  const [isChainAdded, setChainAdded] = useState(false);
+  const [chainStatusMessage, setChainStatusMessage] = useState("");
+
+  const checkChain = useCallback(async () => {
+    if (window.keplr) {
+      try {
+        const key = await window.keplr.getKey("athens_7001-1");
+        if (key) {
+          setChainAdded(true);
+          setChainStatusMessage(
+            "☑️ ZetaChain Athens 3 testnet is already added to your Keplr extension."
+          );
+        } else {
+          setChainAdded(false);
+          setChainStatusMessage("ZetaChain has not been added yet");
+        }
+      } catch (error) {
+        console.error("Error getting key:", error);
+      }
+    } else {
+      setChainAdded(false);
+      setChainStatusMessage(
+        "🤷‍♂️ Keplr extension not detected. Please install and return to this page to add ZetaChain to Keplr."
+      );
+    }
+  }, []);
+
+  const handleButtonClick = async () => {
+    const chainInfo = {
+      rpc: "https://zetachain-athens.blockpi.network/rpc/v1/public",
+      rest: "https://zetachain-athens.blockpi.network/lcd/v1/public",
+      chainId: "athens_7001-1",
+      chainName: "ZetaChain Athens 3 Testnet",
+      chainSymbolImageUrl:
+        "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/athens_7001/chain.png",
+      stakeCurrency: {
+        coinDenom: "ZETA",
+        coinMinimalDenom: "azeta",
+        coinDecimals: 18,
+      },
+      nodeProvider: {
+        name: "BlockPI",
+        email: "help@blockpi.io",
+        website: "https://blockpi.io/",
+      },
+      bip44: {
+        coinType: 60,
+      },
+      bech32Config: {
+        bech32PrefixAccAddr: "zeta",
+        bech32PrefixAccPub: "zetapub",
+        bech32PrefixValAddr: "zetavaloper",
+        bech32PrefixValPub: "zetavaloperpub",
+        bech32PrefixConsAddr: "ezetaalcons",
+        bech32PrefixConsPub: "zetavalconspub",
+      },
+      currencies: [
+        {
+          coinDenom: "tZETA",
+          coinMinimalDenom: "azeta",
+          coinDecimals: 18,
+        },
+      ],
+      feeCurrencies: [
+        {
+          coinDenom: "tZETA",
+          coinMinimalDenom: "azeta",
+          coinDecimals: 18,
+          gasPriceStep: {
+            low: 80000000000,
+            average: 80000000000,
+            high: 80000000000,
+          },
+        },
+      ],
+      features: ["eth-address-gen", "eth-key-sign"],
+    };
+
+    if (window.keplr && window.keplr.experimentalSuggestChain) {
+      try {
+        await window.keplr.experimentalSuggestChain(chainInfo);
+        checkChain();
+      } catch (error) {
+        console.error("Error suggesting chain:", error);
+        setChainStatusMessage(
+          "Failed to suggest ZetaChain to Keplr extension."
+        );
+      }
+    } else {
+      checkChain();
+      console.error("Keplr extension not detected.");
+    }
+  };
+
+  useEffect(() => {
+    checkChain();
+  }, [checkChain]);
+
+  return (
+    <div>
+      <p>{chainStatusMessage}</p>
+      {!isChainAdded && window.keplr && (
+        <button
+          className="border border-grey-200 dark:border-grey-500 rounded p-3 hover:border-green-100 hover:dark:border-green-100 transition-[border-color]"
+          onClick={handleButtonClick}
+          disabled={isChainAdded}
+        >
+          Add ZetaChain to Keplr
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default Keplr;

--- a/src/components/Keplr/Keplr.tsx
+++ b/src/components/Keplr/Keplr.tsx
@@ -5,20 +5,22 @@ export const Keplr: React.FC<{}> = () => {
   const [chainStatusMessage, setChainStatusMessage] = useState("");
 
   const checkChain = useCallback(async () => {
-    if (window.keplr) {
-      try {
-        const key = await window.keplr.getKey("athens_7001-1");
-        if (key) {
-          setChainAdded(true);
-          setChainStatusMessage(
-            "☑️ ZetaChain Athens 3 testnet is already added to your Keplr extension."
-          );
-        } else {
-          setChainAdded(false);
-          setChainStatusMessage("ZetaChain has not been added yet");
+    if (typeof window !== "undefined" && window.keplr) {
+      if (window && window.keplr) {
+        try {
+          const key = await window.keplr.getKey("athens_7001-1");
+          if (key) {
+            setChainAdded(true);
+            setChainStatusMessage(
+              "☑️ ZetaChain Athens 3 testnet is already added to your Keplr extension."
+            );
+          } else {
+            setChainAdded(false);
+            setChainStatusMessage("ZetaChain has not been added yet");
+          }
+        } catch (error) {
+          console.error("Error getting key:", error);
         }
-      } catch (error) {
-        console.error("Error getting key:", error);
       }
     } else {
       setChainAdded(false);
@@ -79,7 +81,11 @@ export const Keplr: React.FC<{}> = () => {
       features: ["eth-address-gen", "eth-key-sign"],
     };
 
-    if (window.keplr && window.keplr.experimentalSuggestChain) {
+    if (
+      typeof window !== "undefined" &&
+      window.keplr &&
+      window.keplr.experimentalSuggestChain
+    ) {
       try {
         await window.keplr.experimentalSuggestChain(chainInfo);
         checkChain();
@@ -96,13 +102,15 @@ export const Keplr: React.FC<{}> = () => {
   };
 
   useEffect(() => {
-    checkChain();
+    if (typeof window !== "undefined") {
+      checkChain();
+    }
   }, [checkChain]);
 
   return (
     <div>
       <p>{chainStatusMessage}</p>
-      {!isChainAdded && window.keplr && (
+      {typeof window !== "undefined" && !isChainAdded && window.keplr && (
         <button
           className="border border-grey-200 dark:border-grey-500 rounded p-3 hover:border-green-100 hover:dark:border-green-100 transition-[border-color]"
           onClick={handleButtonClick}


### PR DESCRIPTION
I'm sure there are better ways to do this, but as a quick solution, I think a simple button might work. Being able to add ZetaChain to Keplr is a prerequisite for adding ZetaChain support for some Cosmos-based explorers.

Add Keplr button:

<img width="1728" alt="Screenshot 2023-06-22 at 21 02 38" src="https://github.com/zeta-chain/docs/assets/332151/85b3b51a-41c9-4c26-bc1c-a1cc084b2cff">

Keplr's popup:

<img width="1728" alt="Screenshot 2023-06-22 at 21 02 48" src="https://github.com/zeta-chain/docs/assets/332151/6a5b6cc6-b4ce-4265-a93e-da390e1770d7">

ZetaChain has already been added:

<img width="1728" alt="Screenshot 2023-06-22 at 21 02 56" src="https://github.com/zeta-chain/docs/assets/332151/bd971ee0-3689-41d1-a65c-ced3af731375">

Extension not installed:

<img width="1728" alt="Screenshot 2023-06-22 at 21 06 30" src="https://github.com/zeta-chain/docs/assets/332151/19958241-1a81-4ceb-8a91-8556bd97120b">

