### PR TITLE
ci: fetch docs from zeta-node

### DIFF
--- a/.github/workflows/update-from-zeta-node.yaml
+++ b/.github/workflows/update-from-zeta-node.yaml
@@ -1,0 +1,36 @@
+name: Update docs/modules from zeta-node
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Checkout zeta-node repository
+        uses: actions/checkout@v2
+        with:
+          repository: zeta-chain/protocol-contracts
+          path: protocol-contracts
+
+      - name: Replace contents of docs/modules
+        run: |
+          rm -rf docs/data/*
+          cp -r protocol-contracts/data/* docs/data/
+
+      - name: Check for changes
+        id: check-changes
+        run: |
+          git diff --exit-code docs/data/ || echo "::set-output name=changed::true"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: Update docs/modules from zeta-node
+          commit-message: Update docs/modules from zeta-node
+          branch: update-docs-modules
+        if: steps.check-changes.outputs.changed == 'true'

--- a/.github/workflows/update-from-zeta-node.yaml
+++ b/.github/workflows/update-from-zeta-node.yaml
@@ -20,6 +20,7 @@ jobs:
 
       - name: Replace contents of docs/modules
         run: |
+          mkdir -p docs/data
           rm -rf docs/data/*
           cp -r protocol-contracts/data/* docs/data/
 

--- a/.github/workflows/update-from-zeta-node.yaml
+++ b/.github/workflows/update-from-zeta-node.yaml
@@ -1,8 +1,10 @@
-name: Update docs/modules from zeta-node
+name: Update module specs from zeta-node
 
 on:
-  pull_request:
-    types: [synchronize, reopened]
+  schedule:
+    - cron: "0 0 * * *" # scheduled to run every day at midnight
+  repository_dispatch:
+    types: [manual-trigger]
 
 jobs:
   update-docs:
@@ -15,19 +17,19 @@ jobs:
       - name: Checkout protocol-contracts repository
         uses: actions/checkout@v2
         with:
-          repository: zeta-chain/protocol-contracts
-          path: protocol-contracts
+          repository: zeta-chain/zeta-node
+          path: zeta-node
 
       - name: Replace contents of docs/modules
         run: |
-          mkdir -p docs/data
-          rm -rf docs/data/*
-          cp -r protocol-contracts/data/* docs/data/
+          mkdir -p docs/architecture/modules
+          rm -rf docs/architecture/modules/*
+          cp -r zeta-node/docs/spec/* docs/architecture/modules/
 
       - name: Check for changes
         id: check-changes
         run: |
-          git add docs/data/
+          git add docs/architecture/modules
           git diff --cached --exit-code docs/data/ || echo "::set-output name=changed::true"
 
       - name: Create Pull Request

--- a/.github/workflows/update-from-zeta-node.yaml
+++ b/.github/workflows/update-from-zeta-node.yaml
@@ -36,4 +36,5 @@ jobs:
           title: Update docs/modules from zeta-node
           commit-message: Update docs/modules from zeta-node
           branch: update-docs-modules
+          base: ci/zeta-node
         if: steps.check-changes.outputs.changed == 'true'

--- a/.github/workflows/update-from-zeta-node.yaml
+++ b/.github/workflows/update-from-zeta-node.yaml
@@ -27,7 +27,8 @@ jobs:
       - name: Check for changes
         id: check-changes
         run: |
-          git diff --exit-code docs/data/ || echo "::set-output name=changed::true"
+          git add docs/data/
+          git diff --cached --exit-code docs/data/ || echo "::set-output name=changed::true"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/update-from-zeta-node.yaml
+++ b/.github/workflows/update-from-zeta-node.yaml
@@ -35,6 +35,6 @@ jobs:
         with:
           title: Update docs/modules from zeta-node
           commit-message: Update docs/modules from zeta-node
-          branch: update-docs-modules
           base: ci/zeta-node
+          branch: update-docs-modules
         if: steps.check-changes.outputs.changed == 'true'

--- a/.github/workflows/update-from-zeta-node.yaml
+++ b/.github/workflows/update-from-zeta-node.yaml
@@ -35,8 +35,11 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
-          title: Update docs/modules from zeta-node
-          commit-message: Update docs/modules from zeta-node
-          base: ci/zeta-node
-          branch: update-docs-modules
+          title: "docs: update module specs from zeta-node"
+          body:
+            This PR contains updates to the Cosmos SDK module specifications
+            from the `zeta-node` repository.
+          commit-message: "docs: update module specs from zeta-node"
+          base: main
+          branch: docs/updates-from-zeta-node
         if: steps.check-changes.outputs.changed == 'true'

--- a/.github/workflows/update-from-zeta-node.yaml
+++ b/.github/workflows/update-from-zeta-node.yaml
@@ -1,17 +1,21 @@
 name: Update docs/modules from zeta-node
 
 on:
-  workflow_dispatch:
+  issue_comment:
+    types: [created]
 
 jobs:
   update-docs:
+    if:
+      github.event.issue.pull_request != '' &&
+      contains(github.event.comment.body, '/update-docs')
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Checkout zeta-node repository
+      - name: Checkout protocol-contracts repository
         uses: actions/checkout@v2
         with:
           repository: zeta-chain/protocol-contracts

--- a/.github/workflows/update-from-zeta-node.yaml
+++ b/.github/workflows/update-from-zeta-node.yaml
@@ -1,14 +1,11 @@
 name: Update docs/modules from zeta-node
 
 on:
-  issue_comment:
-    types: [created]
+  pull_request:
+    types: [synchronize, reopened]
 
 jobs:
   update-docs:
-    if:
-      github.event.issue.pull_request != '' &&
-      contains(github.event.comment.body, '/update-docs')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
A workflow that should checkout the `zeta-node` repo and copy the contents of the [`docs/spec`](https://github.com/zeta-chain/zeta-node/tree/993d0a6f7bc4aaec6420d70654bcd64abe085620/docs/spec) directory into `docs/architecture/modules`. If there are differences, create a PR. If the PR isn't merged and there are more updates it will force push into the same PR branch.

Triggered at midnight and manually (just in case we want to manually update the docs for something urgent).