### PR TITLE
ci: deploy to production workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,23 @@
+name: Deploy to Production
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+on:
+  push:
+    tags:
+      - "*"
+jobs:
+  Deploy-Production:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+      - name: Pull Vercel Environment Information
+        run:
+          vercel pull --yes --environment=production --token=${{
+          secrets.VERCEL_TOKEN }}
+      - name: Build Project Artifacts
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
I’m proposing we switch to a release-based deployment for the docs. It’s almost what we have right now, except instead of merging into the `release` branch, we just press a button on GH to create a release. Feel a bit cleaner and we get a nice changelog in the release section, which is nice.

Based on https://vercel.com/guides/can-you-deploy-based-on-tags-releases-on-vercel

cc @lucas-janon 