### PR TITLE
docs: update module state changes

### DIFF
--- a/docs/architecture/modules/crosschain/messages.md
+++ b/docs/architecture/modules/crosschain/messages.md
@@ -172,31 +172,4 @@ message MsgSetNodeKeys {
 }
 ```
 
-## MsgUpdatePermissionFlags
-
-Updates permissions. Currently, this is only used to enable/disable the
-inbound transactions.
-
-Only the admin policy account is authorized to broadcast this message.
-
-```proto
-message MsgUpdatePermissionFlags {
-	string creator = 1;
-	bool isInboundEnabled = 3;
-}
-```
-
-## MsgUpdateKeygen
-
-Updates the block height of the keygen and sets the status to "pending
-keygen".
-
-Only the admin policy account is authorized to broadcast this message.
-
-```proto
-message MsgUpdateKeygen {
-	string creator = 1;
-	int64 block = 2;
-}
-```
 

--- a/docs/architecture/modules/crosschain/overview.md
+++ b/docs/architecture/modules/crosschain/overview.md
@@ -72,8 +72,6 @@ status is changed to final.
 | MsgVoteOnObservedInboundTx  |                      | ✅                 |
 | MsgAddToOutTxTracker        | ✅                   | ✅                 |
 | MsgRemoveFromOutTxTracker   | ✅                   |                    |
-| MsgUpdatePermissionFlags    | ✅                   |                    |
-| MsgUpdateKeygenPermission   | ✅                   |                    |
 
 ## State
 
@@ -83,8 +81,6 @@ The module stores the following information in the state:
 - List of chain nonces
 - List of last chain heights
 - List of cross-chain transactions
-- List of
 - Mapping between inbound transactions and cross-chain transactions
-- Keygen
 - TSS key
 - Gas prices on connected chains submitted by observers

--- a/docs/architecture/modules/fungible/overview.md
+++ b/docs/architecture/modules/fungible/overview.md
@@ -1,6 +1,6 @@
 # Overview
 
-The `fungible` facilitates the deployment of fungible tokens of connected
+The `fungible` module facilitates the deployment of fungible tokens of connected
 blockchains (called "foreign coins") on ZetaChain.
 
 Foreign coins are represented as ZRC20 tokens on ZetaChain.

--- a/docs/architecture/modules/observer/messages.md
+++ b/docs/architecture/modules/observer/messages.md
@@ -29,3 +29,31 @@ message MsgUpdateCoreParams {
 }
 ```
 
+## MsgUpdatePermissionFlags
+
+Updates permissions. Currently, this is only used to enable/disable the
+inbound transactions.
+
+Only the admin policy account is authorized to broadcast this message.
+
+```proto
+message MsgUpdatePermissionFlags {
+	string creator = 1;
+	bool isInboundEnabled = 3;
+}
+```
+
+## MsgUpdateKeygen
+
+Updates the block height of the keygen and sets the status to "pending
+keygen".
+
+Only the admin policy account is authorized to broadcast this message.
+
+```proto
+message MsgUpdateKeygen {
+	string creator = 1;
+	int64 block = 2;
+}
+```
+


### PR DESCRIPTION
Update the module docs with state and message changes:

- `keygen`, `MsgUpdatePermissionFlags`, and `MsgUpdateKeygen` moved from `crosschain` to `observer` module

More globally, I think we should target a date near mainnet for a full docs revamp for the modules with the latest interface for the state and the messages

