### PR TITLE
Add compilation step before deployment

### DIFF
--- a/docs/developers/cross-chain-messaging/examples/cross-chain-counter.md
+++ b/docs/developers/cross-chain-messaging/examples/cross-chain-counter.md
@@ -63,8 +63,10 @@ import "./tasks/counter_increment.ts";
 
 ## Deploy the contract
 
+Compile the contract:
+
 ```
-npx hardhat compile
+npx hardhat compile --force
 ```
 
 ```

--- a/docs/developers/cross-chain-messaging/examples/cross-chain-counter.md
+++ b/docs/developers/cross-chain-messaging/examples/cross-chain-counter.md
@@ -63,7 +63,7 @@ import "./tasks/counter_increment.ts";
 
 ## Deploy the contract
 
-Compile the contract:
+Clear the cache and artifacts, then compile the contract:
 
 ```
 npx hardhat compile --force

--- a/docs/developers/cross-chain-messaging/examples/cross-chain-nft.md
+++ b/docs/developers/cross-chain-messaging/examples/cross-chain-nft.md
@@ -58,7 +58,7 @@ chains and set the interactors for all chains.
 https://github.com/zeta-chain/example-contracts/blob/feat/import-toolkit/messaging/warriors/tasks/deploy.ts
 ```
 
-Compile the contract:
+Clear the cache and artifacts, then compile the contract:
 
 ```
 npx hardhat compile --force

--- a/docs/developers/cross-chain-messaging/examples/cross-chain-nft.md
+++ b/docs/developers/cross-chain-messaging/examples/cross-chain-nft.md
@@ -58,6 +58,12 @@ chains and set the interactors for all chains.
 https://github.com/zeta-chain/example-contracts/blob/feat/import-toolkit/messaging/warriors/tasks/deploy.ts
 ```
 
+Compile the contract:
+
+```
+npx hardhat compile --force
+```
+
 Run the following command to deploy the contract to two networks:
 
 ```

--- a/docs/developers/cross-chain-messaging/examples/multi-chain-value.md
+++ b/docs/developers/cross-chain-messaging/examples/multi-chain-value.md
@@ -68,7 +68,7 @@ the other chain to the list of available chains.
 https://github.com/zeta-chain/example-contracts/blob/feat/import-toolkit/messaging/value/tasks/deploy.ts
 ```
 
-Compile the contract:
+Clear the cache and artifacts, then compile the contract:
 
 ```
 npx hardhat compile --force

--- a/docs/developers/cross-chain-messaging/examples/multi-chain-value.md
+++ b/docs/developers/cross-chain-messaging/examples/multi-chain-value.md
@@ -68,6 +68,12 @@ the other chain to the list of available chains.
 https://github.com/zeta-chain/example-contracts/blob/feat/import-toolkit/messaging/value/tasks/deploy.ts
 ```
 
+Compile the contract:
+
+```
+npx hardhat compile --force
+```
+
 Run the following command to deploy the contract to two networks:
 
 ```

--- a/docs/developers/cross-chain-messaging/examples/your-first-message.md
+++ b/docs/developers/cross-chain-messaging/examples/your-first-message.md
@@ -76,7 +76,7 @@ contract address. If deploying to more than two chains, you must call
 https://github.com/zeta-chain/example-contracts/blob/feat/import-toolkit/messaging/message/tasks/deploy.ts
 ```
 
-Compile the contract:
+Clear the cache and artifacts, then compile the contract:
 
 ```
 npx hardhat compile --force

--- a/docs/developers/cross-chain-messaging/examples/your-first-message.md
+++ b/docs/developers/cross-chain-messaging/examples/your-first-message.md
@@ -76,6 +76,12 @@ contract address. If deploying to more than two chains, you must call
 https://github.com/zeta-chain/example-contracts/blob/feat/import-toolkit/messaging/message/tasks/deploy.ts
 ```
 
+Compile the contract:
+
+```
+npx hardhat compile --force
+```
+
 Run the following command to deploy the contract to two networks:
 
 ```

--- a/docs/developers/omnichain/tutorials/bitcoin.md
+++ b/docs/developers/omnichain/tutorials/bitcoin.md
@@ -47,7 +47,7 @@ the Bitcoin Testnet.
 import "./tasks/deploy";
 ```
 
-Compile the contract:
+Clear the cache and artifacts, then compile the contract:
 
 ```
 npx hardhat compile --force

--- a/docs/developers/omnichain/tutorials/bitcoin.md
+++ b/docs/developers/omnichain/tutorials/bitcoin.md
@@ -47,6 +47,12 @@ the Bitcoin Testnet.
 import "./tasks/deploy";
 ```
 
+Compile the contract:
+
+```
+npx hardhat compile --force
+```
+
 Deploy the contract to ZetaChain.
 
 ```

--- a/docs/developers/omnichain/tutorials/hello.md
+++ b/docs/developers/omnichain/tutorials/hello.md
@@ -118,6 +118,12 @@ deployed contract is logged to the console.
 
 ### Deploy the contract to the ZetaChain testnet
 
+Compile the contract:
+
+```
+npx hardhat compile --force
+```
+
 Execute the following command to deploy `HelloZeta` contract to the
 `zeta_testnet` testnet:
 

--- a/docs/developers/omnichain/tutorials/hello.md
+++ b/docs/developers/omnichain/tutorials/hello.md
@@ -118,7 +118,7 @@ deployed contract is logged to the console.
 
 ### Deploy the contract to the ZetaChain testnet
 
-Compile the contract:
+Clear the cache and artifacts, then compile the contract:
 
 ```
 npx hardhat compile --force

--- a/docs/developers/omnichain/tutorials/single-input-multiple-output.md
+++ b/docs/developers/omnichain/tutorials/single-input-multiple-output.md
@@ -129,6 +129,12 @@ contract MultiOutput is zContract, Ownable {
 
 ## Deploy the Contract
 
+Compile the contract:
+
+```
+npx hardhat compile --force
+```
+
 ```
 npx hardhat deploy --network zeta_testnet
 ```

--- a/docs/developers/omnichain/tutorials/single-input-multiple-output.md
+++ b/docs/developers/omnichain/tutorials/single-input-multiple-output.md
@@ -129,7 +129,7 @@ contract MultiOutput is zContract, Ownable {
 
 ## Deploy the Contract
 
-Compile the contract:
+Clear the cache and artifacts, then compile the contract:
 
 ```
 npx hardhat compile --force

--- a/docs/developers/omnichain/tutorials/swap.md
+++ b/docs/developers/omnichain/tutorials/swap.md
@@ -140,7 +140,7 @@ Getting weth9 address from mainnet: eth-mainnet.
 
 ## Deploying the contract
 
-Compile the contract:
+Clear the cache and artifacts, then compile the contract:
 
 ```
 npx hardhat compile --force

--- a/docs/developers/omnichain/tutorials/swap.md
+++ b/docs/developers/omnichain/tutorials/swap.md
@@ -140,6 +140,12 @@ Getting weth9 address from mainnet: eth-mainnet.
 
 ## Deploying the contract
 
+Compile the contract:
+
+```
+npx hardhat compile --force
+```
+
 Use the standard deploy task to deploy the contract to ZetaChain:
 
 ```

--- a/docs/developers/omnichain/tutorials/withdraw.md
+++ b/docs/developers/omnichain/tutorials/withdraw.md
@@ -115,6 +115,12 @@ who might not have enough funds to cover the gas fee.
 
 ## Deploying the contract
 
+Compile the contract:
+
+```
+npx hardhat compile --force
+```
+
 Use the standard deploy task to deploy the contract to ZetaChain:
 
 ```
@@ -150,9 +156,9 @@ Getting tss address from athens: goerli.
 📝 Transaction hash: 0xc6b72c5cc7b7ec68e0853827eab8cead9664b951bfe66340bd2711e2abdf0013
 ```
 
-You should be able to see the progress of the transaction being tracked on ZetaChain. Once the
-transaction is finalized on ZetaChain, you should see a token transaction to the
-recipient address on the target network.
+You should be able to see the progress of the transaction being tracked on
+ZetaChain. Once the transaction is finalized on ZetaChain, you should see a
+token transaction to the recipient address on the target network.
 
 Congratulations! You have successfully created and deployed the Withdraw
 contract to ZetaChain, and executed a cross-chain transaction by sending tokens

--- a/docs/developers/omnichain/tutorials/withdraw.md
+++ b/docs/developers/omnichain/tutorials/withdraw.md
@@ -115,7 +115,7 @@ who might not have enough funds to cover the gas fee.
 
 ## Deploying the contract
 
-Compile the contract:
+Clear the cache and artifacts, then compile the contract:
 
 ```
 npx hardhat compile --force

--- a/docs/reference/explorers.mdx
+++ b/docs/reference/explorers.mdx
@@ -46,10 +46,10 @@ Install the dependencies:
 yarn
 ```
 
-Compile the contract:
+Clear the cache and artifacts, then compile the contract:
 
 ```
-npx hardhat compile
+npx hardhat compile --force
 ```
 
 Create a wallet:


### PR DESCRIPTION
Using `--force` to compile even if the contracts have been compiled before. `--force` is needed to clear cache and artifacts if users have modified contracts before and want artifacts top reflect the state of the latest version of the source.