### PR TITLE
feat: fetch contract adddresses dynamically

### DIFF
--- a/docs/reference/testnet.mdx
+++ b/docs/reference/testnet.mdx
@@ -4,6 +4,8 @@ id: testnet
 sidebar_position: 1
 ---
 
+import ContractAddresses from "@site/src/components/ContractAddresses/ContractAddresses";
+
 # ZetaChain Testnet
 
 ZetaChain's testnet is live with the latest features, it will be undergoing
@@ -19,62 +21,4 @@ For a list of RPC endpoints, refer to the [API endpoints page](/reference/api).
 
 :::
 
-## ZetaChain
-
-| Name              | Value                                      |
-| :---------------- | :----------------------------------------- |
-| connector         | 0x239e96c8f17C85c30100AC26F635Ea15f23E9c67 |
-| tss               | 0x7c125C1d515b8945841b3d5144a060115C58725F |
-| tssUpdater        | 0x7274d1d5dddef36aac53dd45b93487ce01ef0a55 |
-| zetaToken         | 0x5F0b1a82749cb4E2278EC87F8BF6B618dC71a8bf |
-| systemContract    | 0x91d18e54DAf4F677cB28167158d6dd21F6aB3921 |
-| uniswapv2Factory  | 0x9fd96203f7b22bCF72d9DCb40ff98302376cE09c |
-| uniswapv2Router02 | 0x2ca7d64A7EFE2D62A725E2B35Cf7230D6677FfEe |
-| fungibleModule    | 0x735b14BB79463307AAcBED86DAf3322B1e6226aB |
-
-## Goerli Testnet
-
-| Name                    | Value                                      |
-| ----------------------- | ------------------------------------------ |
-| connector               | 0x00005e3125aba53c5652f9f0ce1a4cf91d8b15ea |
-| tss                     | 0x8531a5aB847ff5B22D855633C25ED1DA3255247e |
-| tssUpdater              | 0x55122f7590164Ac222504436943FAB17B62F5d7d |
-| zetaToken               | 0x0000c304d2934c00db1d51995b9f6996affd17c0 |
-| erc20Custody            | 0x000047f11c6e42293f433c82473532e869ce4ec5 |
-| immutableCreate2Factory | 0x095a03c6a68137fE9a566bBc3e552F299d8b886d |
-| zetaTokenConsumerUniV2  | 0xA8D9F0208eB6fE1BC284e7adA84E22E9B40a04f2 |
-| zrc20                   | 0x13A0c5930C028511Dc02665E7285134B6d11A5f4 |
-
-## Mumbai Testnet
-
-| Name                    | Value                                      |
-| ----------------------- | ------------------------------------------ |
-| connector               | 0x0000ecb8cdd25a18f12daa23f6422e07fbf8b9e1 |
-| tss                     | 0x8531a5aB847ff5B22D855633C25ED1DA3255247e |
-| tssUpdater              | 0x55122f7590164Ac222504436943FAB17B62F5d7d |
-| zetaToken               | 0x0000c9ec4042283e8139c74f4c64bcd1e0b9b54f |
-| erc20Custody            | 0x0000a7db254145767262c6a81a7ee1650684258e |
-| immutableCreate2Factory | 0x095a03c6a68137fE9a566bBc3e552F299d8b886d |
-| zetaTokenConsumerUniV3  | 0x60E6b70bC2761f878Ff992276612F67FbABC1761 |
-| zrc20                   | 0x48f80608B672DC30DC7e3dbBd0343c5F02C738Eb |
-
-## BSC Testnet
-
-| Name                    | Value                                      |
-| ----------------------- | ------------------------------------------ |
-| connector               | 0x0000ecb8cdd25a18f12daa23f6422e07fbf8b9e1 |
-| tss                     | 0x8531a5aB847ff5B22D855633C25ED1DA3255247e |
-| tssUpdater              | 0x55122f7590164Ac222504436943FAB17B62F5d7d |
-| zetaToken               | 0x0000c9ec4042283e8139c74f4c64bcd1e0b9b54f |
-| erc20Custody            | 0x0000a7db254145767262c6a81a7ee1650684258e |
-| immutableCreate2Factory | 0x095a03c6a68137fE9a566bBc3e552F299d8b886d |
-| zetaTokenConsumerUniV2  | 0x30a7c9F471cfc2c65A57F04Ef5AB926eD59CE620 |
-| zetaTokenConsumerUniV3  | 0xE842Ed39DD86d9226129a25F0177a53180c7adeF |
-| zrc20                   | 0xd97B1de3619ed2c6BEb3860147E30cA8A7dC9891 |
-
-## Bitcoin Testnet
-
-| Name  | Value                                      |
-| ----- | ------------------------------------------ |
-| tss   | tb1qy9pqmk2pd9sv63g27jt8r657wy0d9ueeh0nqur |
-| zrc20 | 0x65a45c57636f9BcCeD4fe193A602008578BcA90b |
+<ContractAddresses />

--- a/src/components/ContractAddresses/ContractAddresses.tsx
+++ b/src/components/ContractAddresses/ContractAddresses.tsx
@@ -12,6 +12,12 @@ interface FetchedData {
   [key: string]: NestedObject;
 }
 
+const edgeCases: { [key: string]: string } = {
+  ccm: "CCM",
+  zevm: "zEVM",
+  bsc: "BSC",
+};
+
 const DataFetch: React.FC = () => {
   const [data, setData] = useState<FetchedData | null>(null);
 
@@ -29,20 +35,12 @@ const DataFetch: React.FC = () => {
   }
 
   const formatTitle = (title: string) => {
-    return title
-      .split("_")
-      .join(" ")
-      .split(" ")
-      .map((word) =>
-        word.toLowerCase() === "ccm"
-          ? "CCM"
-          : word.toLowerCase() === "bsc"
-          ? "BSC"
-          : word.toLowerCase() === "zevm"
-          ? "zEVM"
-          : word.charAt(0).toUpperCase() + word.slice(1)
-      )
-      .join(" ");
+    const handleEdgeCases = (word: string) => {
+      const upper = word.charAt(0).toUpperCase() + word.slice(1);
+      const edgeCase = edgeCases[word.toLowerCase()];
+      return edgeCase ? edgeCase : upper;
+    };
+    return title.replace(/_/g, " ").split(" ").map(handleEdgeCases).join(" ");
   };
 
   const renderTable = (tableData: DataObject, title: string): ReactNode => {

--- a/src/components/ContractAddresses/ContractAddresses.tsx
+++ b/src/components/ContractAddresses/ContractAddresses.tsx
@@ -1,0 +1,91 @@
+import React, { useState, useEffect, ReactNode } from "react";
+
+interface DataObject {
+  [key: string]: string;
+}
+
+interface NestedObject {
+  [key: string]: DataObject;
+}
+
+interface FetchedData {
+  [key: string]: NestedObject;
+}
+
+const DataFetch: React.FC = () => {
+  const [data, setData] = useState<FetchedData | null>(null);
+
+  useEffect(() => {
+    fetch(
+      "https://raw.githubusercontent.com/zeta-chain/protocol-contracts/main/data/addresses.json"
+    )
+      .then((response) => response.json())
+      .then((jsonData) => setData(jsonData as FetchedData))
+      .catch((error) => console.error("Error:", error));
+  }, []);
+
+  if (!data) {
+    return <div>Loading...</div>;
+  }
+
+  const formatTitle = (title: string) => {
+    return title
+      .split("_")
+      .join(" ")
+      .split(" ")
+      .map((word) =>
+        word.toLowerCase() === "ccm"
+          ? "CCM"
+          : word.toLowerCase() === "bsc"
+          ? "BSC"
+          : word.toLowerCase() === "zevm"
+          ? "zEVM"
+          : word.charAt(0).toUpperCase() + word.slice(1)
+      )
+      .join(" ");
+  };
+
+  const renderTable = (tableData: DataObject, title: string): ReactNode => {
+    const validEntries = Object.entries(tableData).filter(
+      ([key, value]) => value && value.trim() !== ""
+    );
+
+    if (validEntries.length === 0) {
+      return null;
+    }
+
+    return (
+      <div key={title}>
+        <h2>{formatTitle(title)}</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            {validEntries.map(([key, value]) => (
+              <tr key={key}>
+                <td>{key}</td>
+                <td>{value}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  };
+
+  return (
+    <div>
+      {Object.entries(data).map(([key, value]) => {
+        return Object.entries(value).map(([subKey, subValue]) =>
+          renderTable(subValue, `${key} - ${subKey}`)
+        );
+      })}
+    </div>
+  );
+};
+
+export default DataFetch;

--- a/src/components/ContractAddresses/ContractAddresses.tsx
+++ b/src/components/ContractAddresses/ContractAddresses.tsx
@@ -18,13 +18,14 @@ const edgeCases: { [key: string]: string } = {
   bsc: "BSC",
 };
 
+const addressesURL =
+  "https://raw.githubusercontent.com/zeta-chain/protocol-contracts/main/data/addresses.json";
+
 const DataFetch: React.FC = () => {
   const [data, setData] = useState<FetchedData | null>(null);
 
   useEffect(() => {
-    fetch(
-      "https://raw.githubusercontent.com/zeta-chain/protocol-contracts/main/data/addresses.json"
-    )
+    fetch(addressesURL)
       .then((response) => response.json())
       .then((jsonData) => setData(jsonData as FetchedData))
       .catch((error) => console.error("Error:", error));
@@ -58,8 +59,8 @@ const DataFetch: React.FC = () => {
         <table>
           <thead>
             <tr>
-              <th>Name</th>
-              <th>Value</th>
+              <th>Label</th>
+              <th>Contract address</th>
             </tr>
           </thead>
           <tbody>


### PR DESCRIPTION
Making data in `protocol-contracts` the source of truth for contract addresses.