### PR TITLE
fix: bad links

### DIFF
--- a/docs/developers/omnichain/tutorials/curve.md
+++ b/docs/developers/omnichain/tutorials/curve.md
@@ -27,7 +27,7 @@ it take a look to official script, does all the work for you out of the box
 [deployment script](https://github.com/curvefi/curve-contract/blob/master/scripts/deploy.py)),
 using the address of three ZRC-2020 tokens. You can find the ZetaChain addresses
 of ZRC-20 tokens supported right now on the Athens-2 testnet using this
-[endpoint](https://api.athens2.zetachain.com/#/Query/ZetachainZetacoreFungibleForeignCoinsAll).
+[endpoint](DOES NOT WORK https://api.athens2.zetachain.com/#/Query/ZetachainZetacoreFungibleForeignCoinsAll).
 
 ## Implement a cross-chain stableswap
 

--- a/docs/reference/api.mdx
+++ b/docs/reference/api.mdx
@@ -20,7 +20,7 @@ reading Ethereum-formatted transactions or sending them to the network
 For example, querying the latest block number:
 
 ```
-curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' https://api.athens2.zetachain.com/evm
+curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' https://rpc.ankr.com/zetachain_evm_athens_testnet
 ```
 
 ## Tendermint HTTP

--- a/docs/validators/node.mdx
+++ b/docs/validators/node.mdx
@@ -59,17 +59,10 @@ mkdir /home/zetachain/.zetacored/config
 
 ### Download and Install the zetacored binary
 
-Binaries are built based on OS version and CPU architecture. The available
-binaries are:
+Binaries are built based on OS version and CPU architecture. You can download the latest binaries from our [ZetaChain Node GitHub Repo](https://github.com/zeta-chain/node/releases)
 
-```
-https://zetachain-external-files.s3.amazonaws.com/binaries/athens3/latest/zetacored-zetacored-alpine-amd64
-https://zetachain-external-files.s3.amazonaws.com/binaries/athens3/latest/zetacored-ubuntu-20-amd64
-https://zetachain-external-files.s3.amazonaws.com/binaries/athens3/latest/zetacored-ubuntu-22-amd64
-https://zetachain-external-files.s3.amazonaws.com/binaries/athens3/latest/zetacored-ubuntu-22-arm64
-```
 
-Install it as follows:
+Install it in your PATH:
 
 ```
 /usr/local/bin/zetacored

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -41,7 +41,7 @@ const constants = {
   athensChainId: 7001,
   athensNetworkName: "ZetaChain Athens 2",
   athensGasTokenName: "ZETA",
-  athensEVMRPCEndpoint: "https://api.athens2.zetachain.com/evm",
+  athensEVMRPCEndpoint: "https://zetachain-athens-evm.blockpi.network/v1/rpc/public",
   athensExplorer: "https://explorer.zetachain.com",
   athensSystemContractAddress: "0x239e96c8f17C85c30100AC26F635Ea15f23E9c67",
 


### PR DESCRIPTION
Fixed bad or out of date URLs for zeta node binaries and removed some references to old athens2 APIs. 