### PR TITLE
Define type explicitly in `recipient:bytes32` in omnichain tutorials

### DIFF
--- a/docs/developers/omnichain/tutorials/swap.md
+++ b/docs/developers/omnichain/tutorials/swap.md
@@ -48,7 +48,7 @@ yarn add --dev @uniswap/v2-periphery @uniswap/v2-core
 Run the following command to create a new omnichain contract called `Swap`.
 
 ```
-npx hardhat omnichain Swap targetZRC20:address recipient minAmountOut:uint256
+npx hardhat omnichain Swap targetZRC20:address recipient:bytes32 minAmountOut:uint256
 ```
 
 Modify the `onCrossChainCall` function to perform a swap:

--- a/docs/developers/omnichain/tutorials/withdraw.md
+++ b/docs/developers/omnichain/tutorials/withdraw.md
@@ -46,10 +46,10 @@ yarn
 Run the following command to create a new omnichain contract called `Withdraw`.
 
 ```
-npx hardhat omnichain Withdraw recipient
+npx hardhat omnichain Withdraw recipient:bytes32
 ```
 
-You're passing a `recipient` parameter (`bytes32` by default) to the command to
+You're passing a `recipient` parameter of type `bytes32` to the command to
 specify the arguments to the cross-chain call. These parameters will be used to
 generate the `onCrossChainCall` function and the `interact` task.
 


### PR DESCRIPTION
Since we're switching to using strings as the default, it's better to define types explicitly.

Context: https://github.com/zeta-chain/toolkit/pull/37