### PR TITLE
fix: OpenAPI URL

### DIFF
--- a/docs/reference/openapi.mdx
+++ b/docs/reference/openapi.mdx
@@ -5,5 +5,11 @@ sidebar_label: ZetaChain HTTP API
 
 import SwaggerUI from "swagger-ui-react";
 import "swagger-ui-react/swagger-ui.css";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 
-<SwaggerUI url="/data/openapi.swagger.yaml" />
+export const OpenAPI = () => {
+  const { siteConfig } = useDocusaurusContext();
+  return <SwaggerUI url={siteConfig.baseUrl + "data/openapi.swagger.yaml"} />;
+};
+
+<OpenAPI />


### PR DESCRIPTION
Added `baseUrl` to the URL to fetch the OpenAPI YAML correctly.

<img width="1840" alt="Screenshot 2023-08-24 at 15 10 57" src="https://github.com/zeta-chain/docs/assets/332151/74cb04a2-0945-44de-9c6a-b58700f6dbb1">
