### PR TITLE
ci: OpenAPI hostname now being added correctly

### DIFF
--- a/.github/workflows/update-from-zeta-node.yaml
+++ b/.github/workflows/update-from-zeta-node.yaml
@@ -30,7 +30,7 @@ jobs:
           mkdir -p static/data
           rm -rf static/data/openapi.swagger.yaml
           cp -r node/docs/openapi/openapi.swagger.yaml static/data/
-          echo "\nhost: zetachain-athens.blockpi.network/lcd/v1/public" >> static/data/openapi.swagger.yaml
+          echo -e "\nhost: zetachain-athens.blockpi.network/lcd/v1/public" >> static/data/openapi.swagger.yaml
           rm -rf node
 
       - name: Check for changes


### PR DESCRIPTION
GH workflow script added hostname incorrectly:

https://github.com/zeta-chain/docs/blob/f9add3d8c0fb8f61881c0060155bfb5a572d033d/static/data/openapi.swagger.yaml#L51014

<img width="1840" alt="Screenshot 2023-09-01 at 12 30 43" src="https://github.com/zeta-chain/docs/assets/332151/e41fa8c4-f14d-470c-981b-617c0c8622c7">
