### PR TITLE
Styling fixes for the OpenAPI browser

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -320,16 +320,22 @@ mark {
   text-decoration: line-through;
 }
 
-html[data-theme="dark"] {
-  @media (prefers-color-scheme: dark) {
-    .swagger-ui {
-      filter: invert(88%) hue-rotate(180deg);
-    }
-    .swagger-ui .microlight {
-      filter: invert(100%) hue-rotate(180deg);
-    }
-    .markdown pre.base-url {
-      background: #fff !important;
-    }
-  }
+html[data-theme="dark"] .swagger-ui {
+  filter: invert(88%) hue-rotate(180deg);
+}
+
+html[data-theme="dark"] .swagger-ui .microlight {
+  filter: invert(100%) hue-rotate(180deg);
+}
+
+html[data-theme="dark"] .markdown pre.base-url {
+  background: #fff !important;
+}
+
+.markdown code {
+  background: none !important;
+}
+
+html[data-theme="dark"] .swagger-ui .opblock-body pre.microlight {
+  background: black !important;
 }


### PR DESCRIPTION
Before:

<img width="1840" alt="Screenshot 2023-09-06 at 11 33 26" src="https://github.com/zeta-chain/docs/assets/332151/829ca1bf-c387-4d9c-8cb9-a5eb8ed72e02">

After:

<img width="1840" alt="Screenshot 2023-09-06 at 11 33 04" src="https://github.com/zeta-chain/docs/assets/332151/769142c4-7216-4ae9-831b-12b86e22c91f">
