### PR TITLE
Automatically update zetacored docs from the node repo

### DIFF
--- a/.github/workflows/update-from-zeta-node.yaml
+++ b/.github/workflows/update-from-zeta-node.yaml
@@ -19,13 +19,19 @@ jobs:
           repository: zeta-chain/node
           path: node
 
-      - name: Replace contents of docs/modules
+      - name: Update module docs
         run: |
           mkdir -p docs/architecture/modules
           rm -rf docs/architecture/modules/*
           cp -r node/docs/spec/* docs/architecture/modules/
 
-      - name: Replace OpenAPI specs
+      - name: Update zetacored CLI docs
+        run: |
+          mkdir -p docs/architecture/zetacored
+          rm -rf docs/architecture/zetacored/*
+          cp -r node/docs/cli/zetacored/* docs/architecture/zetacored/
+
+      - name: Update OpenAPI specs
         run: |
           mkdir -p static/data
           rm -rf static/data/openapi.swagger.yaml


### PR DESCRIPTION
<img width="1840" alt="Screenshot 2023-10-31 at 11 16 13" src="https://github.com/zeta-chain/docs/assets/332151/cf8545b9-47c2-4496-b471-e3a9b1fe6a2e">
