### PR TITLE
Update Cosmovisor docs (fix broken link) and update node docs (add state sync)

### DIFF
--- a/docs/validators/cosmovisor.mdx
+++ b/docs/validators/cosmovisor.mdx
@@ -113,7 +113,7 @@ cp network-athens3/network_files/config/* ~/.zetacored/config/
 You may choose to sync the state of your node from a snapshot. This will speed
 up the time it takes to sync your node. Instructions for syncing from a snapshot
 can be found
-[here](https://docs.zetachain.io/docs/running-a-full-node#state-sync).
+[here](https://www.zetachain.com/docs/validators/running-a-full-node/#state-sync).
 
 ### Start the `cosmovisor` Service
 

--- a/docs/validators/node.mdx
+++ b/docs/validators/node.mdx
@@ -153,6 +153,8 @@ for more information.
 | Ireland (EU West)           | TBD |
 | Singapore (APAC South East) | TBD |
 
+## State Sync
+
 Use the state sync node closer your node. Run the following command to collect
 the `latest block height` and `latest block hash`:
 


### PR DESCRIPTION
1. Update cosmovisor.mdx - Fix broken link

Old: https://docs.zetachain.io/docs/running-a-full-node#state-sync

New: https://www.zetachain.com/docs/validators/running-a-full-node/#state-sync

3. Update node.mdx - Add ## State Sync

Problem: There is no ## State Sync in node.mdx and thus when users open the link above, it won't go direct to State Sync section.

Solution: Add ## State Sync in node.mdx
