### PR TITLE
Swap tutorial: ERC-20 support

### DIFF
--- a/docs/developers/omnichain/system-contract.md
+++ b/docs/developers/omnichain/system-contract.md
@@ -12,7 +12,7 @@ information you may need in your protocol. You can import this code into your
 project and instance with the deployed address. You can find the up-to-date
 address of the system contract using the ZetaChain's API:
 
-https://zetachain-athens.blockpi.network/lcd/v1/public/zeta-chain/zetacore/fungible/system_contract
+https://zetachain-athens.blockpi.network/lcd/v1/public/zeta-chain/fungible/system_contract
 
 In this contract you will find:
 

--- a/docs/developers/omnichain/tutorials/curve.md
+++ b/docs/developers/omnichain/tutorials/curve.md
@@ -27,7 +27,7 @@ it take a look to official script, does all the work for you out of the box
 [deployment script](https://github.com/curvefi/curve-contract/blob/master/scripts/deploy.py)),
 using the address of three ZRC-2020 tokens. You can find the ZetaChain addresses
 of ZRC-20 tokens supported right now on the ZetaChain testnet using this
-[endpoint](https://zetachain-athens.blockpi.network/lcd/v1/public/zeta-chain/zetacore/fungible/foreign_coins).
+[endpoint](https://zetachain-athens.blockpi.network/lcd/v1/public/zeta-chain/fungible/foreign_coins).
 
 ## Implement a cross-chain stableswap
 

--- a/src/components/ForeignCoins/ForeignCoins.tsx
+++ b/src/components/ForeignCoins/ForeignCoins.tsx
@@ -64,10 +64,11 @@ const ForeignCoinsTable = () => {
       <table>
         <thead>
           <tr>
-            <th>Chain Name</th>
+            <th>Chain</th>
             <th>Symbol</th>
-            <th>Coin Type</th>
-            <th>ZRC-20 Contract Address</th>
+            <th>Type</th>
+            <th>ZRC-20 on ZetaChain</th>
+            <th>ERC-20 on Connected Chain</th>
           </tr>
         </thead>
         <tbody>
@@ -77,6 +78,7 @@ const ForeignCoinsTable = () => {
               <td>{coin.symbol}</td>
               <td>{coin.coin_type}</td>
               <td>{coin.zrc20_contract_address}</td>
+              <td>{coin.asset}</td>
             </tr>
           ))}
         </tbody>

--- a/src/components/ForeignCoins/ForeignCoins.tsx
+++ b/src/components/ForeignCoins/ForeignCoins.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 
 const COINS_URL =
-  "https://zetachain-athens.blockpi.network/lcd/v1/public/zeta-chain/zetacore/fungible/foreign_coins";
+  "https://zetachain-athens.blockpi.network/lcd/v1/public/zeta-chain/fungible/foreign_coins";
 const CHAINS_URL =
   "https://zetachain-athens.blockpi.network/lcd/v1/public/zeta-chain/observer/supportedChains";
 


### PR DESCRIPTION
* Updated the swap tutorial to support ERC-20
* Updated the introductory omnichain tutorial with the new interact task that supports sending ERC-20s to the custody contract
* Modified the component that displays supported ZRC-20 and ERC-20 contract addresses
* Updated API URLs in docs and components ot match what's currently on testnet

Related:

https://github.com/zeta-chain/template/pull/37
https://github.com/zeta-chain/example-contracts/pull/99
https://github.com/zeta-chain/toolkit/pull/84