### PR TITLE
Fix state sync docs

### DIFF
--- a/docs/validators/state-sync.mdx
+++ b/docs/validators/state-sync.mdx
@@ -71,11 +71,12 @@ NOTE: You need to sync from LATEST_HEIGHT - 40000 to make sure that the node wil
 RPC_STATE_SYNC_SERVERS="[closest StateSync IP]:26657,[closest StateSync IP]:26657"
 SEED="5aaa51a3b9465a32f7f6c9df1d46d4bfcc16aecb@34.30.34.119:26656"
 EXTERNAL_IP=$(curl -4 icanhazip.com)
+sed -i '' 's/enable = [^ ]*/enable = true/' ~/.zetacored/config/config.toml &&
 sed -i "" -e "s/-=RPC_SERVERS=-/${RPC_STATE_SYNC_SERVERS}/g" ~/.zetacored/config/config.toml &&
-sed -i "" -e "s/-=SYNC_HEIGHT=-/${HEIGHT}/g" ~/.zetacored/config/config.toml &&
+sed -i "" -e "s/-=TRUST_HEIGHT=-/${HEIGHT}/g" ~/.zetacored/config/config.toml &&
 sed -i "" -e "s/-=TRUST_HASH=-/${TRUST_HASH}/g" ~/.zetacored/config/config.toml &&
 sed -i "" -e "s/-=MONIKER=-/${MONIKER}/g" ~/.zetacored/config/config.toml &&
-sed -i "" -e "s/-=external_ip_address=-/${EXTERNAL_IP}/g" ~/.zetacored/config/config.toml
+sed -i "" -e "s/-=external_address=-/${EXTERNAL_IP}:26657/g" ~/.zetacored/config/config.toml
 sed -i "" -e "s/^seeds = .*/seeds = \"${SEED}\"/" ~/.zetacored/config/config.toml
 sed -i "" -e 's/^max_num_inbound_peers = .*/max_num_inbound_peers = 120/' ~/.zetacored/config/config.toml
 sed -i "" -e 's/^max_num_outbound_peers = .*/max_num_outbound_peers = 60/' ~/.zetacored/config/config.toml

--- a/docs/validators/state-sync.mdx
+++ b/docs/validators/state-sync.mdx
@@ -71,14 +71,14 @@ NOTE: You need to sync from LATEST_HEIGHT - 40000 to make sure that the node wil
 RPC_STATE_SYNC_SERVERS="[closest StateSync IP]:26657,[closest StateSync IP]:26657"
 SEED="5aaa51a3b9465a32f7f6c9df1d46d4bfcc16aecb@34.30.34.119:26656"
 EXTERNAL_IP=$(curl -4 icanhazip.com)
-sed -i '' 's/enable = [^ ]*/enable = true/' ~/.zetacored/config/config.toml &&
-sed -i "" -e "s/-=RPC_SERVERS=-/${RPC_STATE_SYNC_SERVERS}/g" ~/.zetacored/config/config.toml &&
-sed -i "" -e "s/-=TRUST_HEIGHT=-/${HEIGHT}/g" ~/.zetacored/config/config.toml &&
-sed -i "" -e "s/-=TRUST_HASH=-/${TRUST_HASH}/g" ~/.zetacored/config/config.toml &&
-sed -i "" -e "s/-=MONIKER=-/${MONIKER}/g" ~/.zetacored/config/config.toml &&
-sed -i "" -e "s/-=external_address=-/${EXTERNAL_IP}:26657/g" ~/.zetacored/config/config.toml
-sed -i "" -e "s/^seeds = .*/seeds = \"${SEED}\"/" ~/.zetacored/config/config.toml
-sed -i "" -e 's/^max_num_inbound_peers = .*/max_num_inbound_peers = 120/' ~/.zetacored/config/config.toml
+sed -i "" -e "s/^enable = .*/enable = \"true\"/" ~/.zetacored/config/config.toml &&
+sed -i "" -e "s/^rpc_servers = .*/rpc_servers = \"${RPC_STATE_SYNC_SERVERS}\"/" ~/.zetacored/config/config.toml &&
+sed -i "" -e "s/^trust_height = .*/trust_height = \"${HEIGHT}\"/" ~/.zetacored/config/config.toml &&
+sed -i "" -e "s/^trust_hash = .*/trust_hash = \"${TRUST_HASH}\"/" ~/.zetacored/config/config.toml &&
+sed -i "" -e "s/^moniker = .*/moniker = \"${MONIKER}\"/" ~/.zetacored/config/config.toml &&
+sed -i "" -e "s/^external_address = .*/external_address = \"${EXTERNAL_IP}\"/" ~/.zetacored/config/config.toml &&
+sed -i "" -e "s/^seeds = .*/seeds = \"${SEED}\"/" ~/.zetacored/config/config.toml &&
+sed -i "" -e 's/^max_num_inbound_peers = .*/max_num_inbound_peers = 120/' ~/.zetacored/config/config.toml &&
 sed -i "" -e 's/^max_num_outbound_peers = .*/max_num_outbound_peers = 60/' ~/.zetacored/config/config.toml
 ```
 

--- a/docs/validators/state-sync.mdx
+++ b/docs/validators/state-sync.mdx
@@ -31,7 +31,7 @@ You can find the available `zetacored` versions here: https://github.com/zeta-ch
 1. Download the binary and give execution perms to the binary:
 
 ```bash
-wget https://github.com/zeta-chain/node/releases/download/v10.1.0/zetacored_testnet-darwin-amd64 -O /usr/local/bin/zetacored
+wget https://github.com/zeta-chain/node/releases/download/[BINARY_VERSION]/zetacored-darwin-amd64 -O /usr/local/bin/zetacored
 chmod a+x /usr/local/bin/zetacored
 ```
 


### PR DESCRIPTION
* Added a `sed` command to enable state sync
* Replaced "sync height" with "trust height", because the former doesn't exist in this config file
* Replaced "external ip addresses" with "external addresses", because the former doesn't exist in this config file. Also, added port number, because it was missing.

Also, these `sed` commands [don't work on macOS](https://stackoverflow.com/questions/4247068/sed-command-with-i-option-failing-on-mac-but-works-on-linux).

Would it makes sense to replace commands like:

```
sed -i "" -e "s/-=RPC_SERVERS=-/${RPC_STATE_SYNC_SERVERS}/g" ~/.zetacored/config/config.toml
```

With something like this:

```
sed -i '' 's|rpc_servers = "[^"]*"|rpc_servers = "'"$RPC_STATE_SYNC_SERVERS"'"|' ~/.zetacored/config/config.toml
```

If so, can someone, please, test these commands on `sed` that comes with Linux? (I'm assuming GNU sed)