### PR TITLE
Use relative links in docs

### DIFF
--- a/docs/developers/cross-chain-messaging/examples/your-first-message.md
+++ b/docs/developers/cross-chain-messaging/examples/your-first-message.md
@@ -210,7 +210,7 @@ to Hardhat.
 To pay for the transaction fees to deploy and interact with the cross-chain
 messaging contracts you will need native gas tokens on the connected chains you
 are deploying contracts to. You can find a list of recommended faucets
-[in the docs](https://www.zetachain.com/docs/reference/get-testnet-zeta/).
+[in the docs](/reference/get-testnet-zeta/).
 
 ## Check Token Balances
 

--- a/docs/developers/omnichain/tutorials/bitcoin-frontend.md
+++ b/docs/developers/omnichain/tutorials/bitcoin-frontend.md
@@ -20,7 +20,7 @@ For the purposes of this tutorial we will be using the
 - [Node.js](https://nodejs.org/en/) installed on your machine with `npm` or
   `yarn`
 - Learn how to
-  [Deposit and call zEVM contracts from Bitcoin](https://www.zetachain.com/docs/developers/omnichain/bitcoin/).
+  [Deposit and call zEVM contracts from Bitcoin](/developers/omnichain/bitcoin/).
 
 # Create a new project
 
@@ -117,7 +117,7 @@ To call an omnichain contract from Bitcoin you need to send a token transfer
 transaction to the ZetaChain's
 [TSS address](https://zetachain.com/docs/reference/testnet) on Bitcoin with a
 memo that conforms to
-[the required format](https://www.zetachain.com/docs/developers/omnichain/bitcoin).
+[the required format](/developers/omnichain/bitcoin).
 
 The memo is composed of two parts:
 
@@ -183,7 +183,7 @@ npx http-server
 Open the page in your browser and fill in the form. You can test functionality
 with your own contract address or follow one of the provided tutorials, for
 example, the
-[Staking](https://www.zetachain.com/docs/developers/omnichain/tutorials/staking/)
+[Staking](/developers/omnichain/tutorials/staking/)
 tutorial to deploy a contract that you can call from Bitcoin.
 
 Fill out the form and click the "Send transaction" button. You will be prompted

--- a/docs/developers/omnichain/tutorials/curve.md
+++ b/docs/developers/omnichain/tutorials/curve.md
@@ -48,4 +48,4 @@ function simply extracts params from the message, calls the Curve pool's
 logic remains in the core Curve contract deployment. Users can interact by
 depositing and calling this zEVM contract from an external chain. You can see
 how you'd call this for a user programmatically
-[here](https://www.zetachain.com/docs/developers/omnichain/zrc-20/).
+[here](/developers/omnichain/zrc-20/).

--- a/docs/reference/wallets.md
+++ b/docs/reference/wallets.md
@@ -31,7 +31,7 @@ To add ZetaChain to the Metamask extension wallet follow these steps:
   - Network Name: `ZetaChain Testnet` (or choose another name)
   - New RPC URL: `https://zetachain-athens-evm.blockpi.network/v1/rpc/public`
     (or choose another one from
-    [the list](https://www.zetachain.com/docs/reference/api/))
+    [the list](/reference/api/))
   - Chain ID: `7001`
   - Currency Symbol: `tZETA`
   - Block explorer URL: `https://athens3.explorer.zetachain.com/`

--- a/docs/validators/cosmovisor.mdx
+++ b/docs/validators/cosmovisor.mdx
@@ -113,7 +113,7 @@ cp network-athens3/network_files/config/* ~/.zetacored/config/
 You may choose to sync the state of your node from a snapshot. This will speed
 up the time it takes to sync your node. Instructions for syncing from a snapshot
 can be found
-[here](https://www.zetachain.com/docs/validators/running-a-full-node/#state-sync).
+[here](/validators/running-a-full-node/#state-sync).
 
 ### Start the `cosmovisor` Service
 
@@ -153,4 +153,5 @@ information.
 See more about your Validator Monitoring [here](/reference/validators-monitoring).
 
 ## More Information About Cosmovisor
+
 For more detailed information about Cosmosvisor you can visit the [Cosmos Documentation Here](https://docs.cosmos.network/main/build/tooling/cosmovisor)


### PR DESCRIPTION
I noticed that some of the links pointed to the prod instance of the docs website. I think using relative links is cleaner, so made this change.