### PR TITLE
Adds Envio as supported subgraph indexer for ZetaChain Mainnet Beta and Testnet

### DIFF
--- a/docs/reference/services.md
+++ b/docs/reference/services.md
@@ -11,6 +11,7 @@ developers.
 | Wallet as a Service | Particle Network | https://particle.network                   |
 | Wallet as a Service | Magic            | https://magic.link/                        |
 | Subgraph            | Goldsky          | https://goldsky.com/                       |
+| Subgraph            | Envio            | https://envio.dev/                         |
 | Explorer            | Blockscout       | https://zetachain-athens-3.blockscout.com/ |
 | Explorer            | Explorer Guru    | https://zetachain.explorers.guru/          |
 | Explorer            | Exploreme        | https://zetachain.exploreme.pro/           |


### PR DESCRIPTION
<img width="1058" alt="Screenshot 2024-02-01 at 18 38 15" src="https://github.com/zeta-chain/docs/assets/102967165/6b506625-91b3-463e-987c-11f775214b2a">
