### PR TITLE
Move protocol contract docs into developers/architecture

### DIFF
--- a/.github/workflows/update-from-protocol-contracts.yaml
+++ b/.github/workflows/update-from-protocol-contracts.yaml
@@ -24,6 +24,7 @@ jobs:
           mkdir -p src/pages/developers/architecture/contracts
           rm -rf src/pages/developers/architecture/contracts/*
           cp -r protocol-contracts/docs/src/* src/pages/developers/architecture/contracts/
+          rm -rf protocol-contracts
 
       - name: Check for changes
         id: check-changes

--- a/.github/workflows/update-from-protocol-contracts.yaml
+++ b/.github/workflows/update-from-protocol-contracts.yaml
@@ -21,9 +21,9 @@ jobs:
 
       - name: Update docs
         run: |
-          mkdir -p src/pages/architecture/contracts
-          rm -rf src/pages/architecture/contracts/*
-          cp -r protocol-contracts/docs/src/* src/pages/architecture/contracts/
+          mkdir -p src/pages/developers/architecture/contracts
+          rm -rf src/pages/developers/architecture/contracts/*
+          cp -r protocol-contracts/docs/src/* src/pages/developers/architecture/contracts/
 
       - name: Check for changes
         id: check-changes

--- a/.github/workflows/update-from-protocol-contracts.yaml
+++ b/.github/workflows/update-from-protocol-contracts.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Check for changes
         id: check-changes
         run: |
-          git add src/pages/architecture/contracts
+          git add src/pages/developers/architecture/contracts
           git diff --cached --exit-code || echo "::set-output name=changed::true"
 
       - name: Create Pull Request


### PR DESCRIPTION
The existing workflow attempts to copy protocol contracts into `src/pages/architecture/contracts`:

Example: https://github.com/zeta-chain/docs/pull/350/files

This PR updates the workflow to move contracts correctly into `src/pages/developers/architecture/contracts`.

Thus fixing the 404: https://www.zetachain.com/docs/developers/architecture/contracts/