### PR TITLE
chore: update toolkit and fix swagger import

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@t3-oss/env-nextjs": "0.7.1",
     "@tailwindcss/line-clamp": "0.4.4",
     "@zetachain/addresses": "0.0.13",
-    "@zetachain/toolkit": "6.0.0",
+    "@zetachain/toolkit": "^10.0.0",
     "@zetachain/ui-toolkit": "1.0.3",
     "axios": "1.6.5",
     "bech32": "2.0.0",

--- a/src/components/Docs/components/Fees.tsx
+++ b/src/components/Docs/components/Fees.tsx
@@ -23,33 +23,33 @@ export const Fees: React.FC<FeesProps> = ({ type }) => {
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    setIsLoading(true);
+    const fetchFees = async () => {
+      setIsLoading(true);
 
-    const client = new ZetaChainClient({ network: activeTab.networkType });
+      try {
+        const client = new ZetaChainClient({ network: activeTab.networkType });
 
-    client
-      .getFees(500000)
-      .then((data: any) => {
+        const data = await client.getFees(500000);
+
         const sortedOmnichainFees = [...data.omnichain].sort((a, b) =>
           a.foreign_chain_id.localeCompare(b.foreign_chain_id)
         );
 
         const updatedData: FeesState = {
-          messaging: data.messaging.filter(
-            (fee: any) => !["18332", "8332"].includes(fee.chainID) // There is a bug in getFees that returns messaging fees for Bitcoin. This filters them out.
-          ),
+          messaging: data.messaging,
           omnichain: sortedOmnichainFees,
         };
 
         if (activeTab.networkType === "mainnet") setMainnetFees(updatedData);
         if (activeTab.networkType === "testnet") setTestnetFees(updatedData);
-
-        setIsLoading(false);
-      })
-      .catch((error: any) => {
+      } catch (error) {
         console.error("Error fetching fees:", error);
+      } finally {
         setIsLoading(false);
-      });
+      }
+    };
+
+    fetchFees();
   }, [activeTab.networkType]);
 
   const fees = useMemo(() => {

--- a/src/components/Docs/components/Fees.tsx
+++ b/src/components/Docs/components/Fees.tsx
@@ -27,8 +27,27 @@ export const Fees: React.FC<FeesProps> = ({ type }) => {
       setIsLoading(true);
 
       try {
-        const client = new ZetaChainClient({ network: activeTab.networkType });
-
+        const client = new ZetaChainClient({
+          network: activeTab.networkType,
+          chains: {
+            zeta_testnet: {
+              api: [
+                {
+                  url: `https://zetachain-athens.g.allthatnode.com/archive/evm`,
+                  type: "evm",
+                },
+              ],
+            },
+            zeta_mainnet: {
+              api: [
+                {
+                  url: `https://zetachain-mainnet.g.allthatnode.com/archive/evm`,
+                  type: "evm",
+                },
+              ],
+            },
+          },
+        });
         const data = await client.getFees(500000);
 
         const sortedOmnichainFees = [...data.omnichain].sort((a, b) =>

--- a/src/components/Docs/components/OpenAPIBrowser.tsx
+++ b/src/components/Docs/components/OpenAPIBrowser.tsx
@@ -2,8 +2,8 @@ import "swagger-ui-react/swagger-ui.css";
 
 import axios from "axios";
 import yaml from "js-yaml";
+import dynamic from "next/dynamic";
 import { useEffect, useMemo, useState } from "react";
-import SwaggerUI from "swagger-ui-react";
 import tw, { styled } from "twin.macro";
 
 import { LoadingTable, NetworkTypeTabs, networkTypeTabs } from "~/components/shared";
@@ -45,6 +45,9 @@ const StyledContainer = styled.div`
     }
   }
 `;
+
+// Dynamically import SwaggerUI to disable server-side rendering
+const SwaggerUI = dynamic(() => import("swagger-ui-react"), { ssr: false });
 
 export const OpenAPIBrowser = () => {
   const [activeTab, setActiveTab] = useState(networkTypeTabs[0]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2851,7 +2851,7 @@
   resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.2.3.tgz#b41053e360c31a32c2640c9a45ee981a7e603fe0"
   integrity sha512-YhzPdzb612X591FOe68q+qXVXGG2ANZRvDo0RRUtimev85rCrAlv/TLMEZw5c+kq9AbzocLTVX/h2jVIFPL9Xg==
 
-"@openzeppelin/contracts@^4.9.2":
+"@openzeppelin/contracts@^4.9.6":
   version "4.9.6"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.9.6.tgz#2a880a24eb19b4f8b25adc2a5095f2aa27f39677"
   integrity sha512-xSmezSupL+y9VkHZJGDoCBpmnB2ogM13ccaYDWqJTfS3dbuHkgjuwDFUmaFauBCboQMGB/S5UqUl2y54X99BmA==
@@ -4908,31 +4908,31 @@
     typescript "5.0.4"
     zod "3.22.4"
 
-"@zetachain/networks@6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@zetachain/networks/-/networks-6.0.0.tgz#ae5d3cd1678b32510edfaa71f8f4a6f4cbc1d9ab"
-  integrity sha512-yKFVP/yJDp76Q5lBGfZSpY/KO3TZ9ldo0lhE4MpBW43EsBxOZWixg6sqb56mcU/gg1lbWG8sHHWtYFK51SByjQ==
+"@zetachain/networks@7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@zetachain/networks/-/networks-7.0.0.tgz#a5f8a188d633e2064ee7c77499351381ba891441"
+  integrity sha512-/amSq+KNJe+EGj0ioZS+DZJtsnbPSDotp9LsrAbaEVMAxKvBK/XkvggH73sJyRWWeMpfhHrNPlrKTLrN+mRkIg==
   dependencies:
     dotenv "^16.1.4"
 
-"@zetachain/protocol-contracts@7.0.0-rc1":
-  version "7.0.0-rc1"
-  resolved "https://registry.yarnpkg.com/@zetachain/protocol-contracts/-/protocol-contracts-7.0.0-rc1.tgz#588483d1ec70e572b7e40e84ef5b34282b0ab375"
-  integrity sha512-vgS+Pjh4MysOyw8WbqTQVBsHJYqKvMcdV7cNVqxaTJd/dl2ak7NNvsIeaeUnxQrp8XfQol2B8GXJpVLM6MK/dg==
+"@zetachain/protocol-contracts@7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@zetachain/protocol-contracts/-/protocol-contracts-7.0.0.tgz#20eb6c62d805d7470408ccdff0e3614684bca174"
+  integrity sha512-8JTNFZxVZYmDtAXJIEr+tkakuML12X42Fya4bJ1NkfWiVMkcSej92BSTl/35qYtHdjY7vXy9uMrfXEqfw5rsPw==
 
-"@zetachain/toolkit@6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@zetachain/toolkit/-/toolkit-6.0.0.tgz#385cfd11f1ac39cbb6ca6410109523e2ab6f8841"
-  integrity sha512-JAtl7CX8cMJ+iw/byjcbLqgCfPS87vkdYCZOPBBOudqUySPTz4owqVgGZB/xYRyXBsF0KW0F6R65sc+fleQ86A==
+"@zetachain/toolkit@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@zetachain/toolkit/-/toolkit-10.0.0.tgz#aceb196d139d7c697e20a48012e0674130e1c0b9"
+  integrity sha512-+Gk5lokCWfqK4Nhm3+TjQb9EgrEyuHcezzxDwvvfjohB0dBor+aRnRyNO1/9+eTqX45M0Cvx4tS51yJCGm0G/g==
   dependencies:
     "@inquirer/prompts" "^2.1.1"
     "@inquirer/select" "1.1.3"
     "@nomiclabs/hardhat-ethers" "^2.2.3"
-    "@openzeppelin/contracts" "^4.9.2"
+    "@openzeppelin/contracts" "^4.9.6"
     "@uniswap/v2-periphery" "^1.1.0-beta.0"
     "@zetachain/faucet-cli" "^4.0.1"
-    "@zetachain/networks" "6.0.0"
-    "@zetachain/protocol-contracts" "7.0.0-rc1"
+    "@zetachain/networks" "7.0.0"
+    "@zetachain/protocol-contracts" "7.0.0"
     axios "^1.4.0"
     bech32 "^2.0.0"
     bip39 "^3.1.0"
@@ -12183,6 +12183,7 @@ streamx@^2.15.0, streamx@^2.16.1:
     bare-events "^2.2.0"
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13365,6 +13366,7 @@ workerpool@6.2.1:
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
Something was wrong with swagger import that introduced a bug: when running `yarn dev` and refreshing a page, like the ZRC-20 or the gas fee page, it would throw an error. This fixes it.

Also, updated toolkit to latest version.

Updated the Fees component and switched from BlockPi to ATN RPC. This is temporary as we need to switch to a global client for the docs (provider) and use our ATN key to ensure that we don't get "too many requests" error.