### PR TITLE
Fix build by removing webpack build worker

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -26,12 +26,6 @@ const baseNextConfig = {
      * https://nextjs.org/docs/app/building-your-application/optimizing/memory-usage#disable-source-maps
      */
     serverSourceMaps: false,
-    /**
-     * The Webpack build worker allows you to run Webpack compilations inside a separate Node.js worker
-     * which will decrease memory usage of your application during builds.
-     * https://nextjs.org/docs/app/building-your-application/optimizing/memory-usage#webpack-build-worker
-     */
-    webpackBuildWorker: true,
   },
   trailingSlash: true,
   basePath: process.env.NEXT_PUBLIC_BASE_PATH,


### PR DESCRIPTION
✅ https://docs-v2-3j82cfwbl.zetachain.app/developers/ (this PR)

❌ https://docs2-staging.zetachain.app/docs/developers/ (main)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved memory usage during builds by removing the `webpackBuildWorker` configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->