### PR TITLE
Fix deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Build Project Artifacts
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel deploy --prebuilt --archive=tgz --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Overview

Seems to fix `Error: Invalid request: `files` should NOT have more than 15000 items, received 17397.`, which we got here: https://github.com/zeta-chain/docs/actions/runs/10182668032/job/28165791116#step:7:11.
See: https://github.com/vercel/vercel/issues/8571#issuecomment-1259816713.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced the deployment process by specifying the archive format for project artifacts in the GitHub Actions workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->