### PR TITLE
Fix ping.pub links

### DIFF
--- a/src/pages/reference/apps/services.mdx
+++ b/src/pages/reference/apps/services.mdx
@@ -21,7 +21,7 @@ developers.
 | Explorer            | Blockscout       | https://zetachain-athens-3.blockscout.com/ |
 | Explorer            | Explorer Guru    | https://zetachain.explorers.guru/          |
 | Explorer            | Exploreme        | https://zetachain.exploreme.pro/           |
-| Explorer            | Ping.Pub         | https://testnet.ping.pub/zetachain         |
+| Explorer            | Ping.Pub         | https://ping.pub/zetachain                 |
 | Explorer            | ZetaScan         | https://explorer.zetachain.com/            |
 | Explorer            | DexGuru          | https://zeta-testnet.dex.guru/             |
 | Wallet              | MetaMask         | https://metamask.io/                       |

--- a/src/pages/users/cli/delegate.mdx
+++ b/src/pages/users/cli/delegate.mdx
@@ -15,7 +15,7 @@ validator to participate in the network and earn rewards.
 
 You can find a list of validators on
 [ZetaScan](https://explorer.zetachain.com/validators), [Ping
-Pub](https://testnet.ping.pub/zetachain/staking), or any [other
+Pub](https://ping.pub/zetachain/staking), or any [other
 explorer](/reference/apps/services/).
 
 Choose the validator you want to delegate to based on their commission rate,
@@ -102,4 +102,4 @@ amount has been deducted.
 You can also confirm the transaction on the explorer by searching for the
 transaction hash:
 
-https://testnet.ping.pub/zetachain/tx/C86E7C0E98A16CA0EB63800DF6CBB80D492201E17AB57229790DCF3403B59D02
+https://ping.pub/zetachain/tx/C86E7C0E98A16CA0EB63800DF6CBB80D492201E17AB57229790DCF3403B59D02

--- a/src/pages/users/pingpub/delegate.mdx
+++ b/src/pages/users/pingpub/delegate.mdx
@@ -8,7 +8,7 @@ Ping Pub is a block explorer for Cosmos based blockchains. Ping Pub features a
 dashboard that allows you to participate in governance, delegate tokens to
 validators, withdraw staking rewards and more.
 
-https://testnet.ping.pub/zetachain
+https://ping.pub/zetachain
 
 ![Ping Pub - Dashboard](/img/docs/ping-dashboard.png)
 


### PR DESCRIPTION
## Overview

`ping.pub` links were pointing to their testnet explorer.