### PR TITLE
Remove base path from <Link />

### DIFF
--- a/src/components/Cmdk/components/MarkdownMesage.tsx
+++ b/src/components/Cmdk/components/MarkdownMesage.tsx
@@ -31,12 +31,11 @@ export const MarkdownMessage: React.FC<MarkdownMessageProps> = ({ closeCmdk, mes
         ),
         a: ({ children, ref, ...args }) => {
           if (typeof args.href !== "string") return null;
-          const isAbsoluteHref = args.href?.startsWith("http");
 
           return (
             <Link
               {...args}
-              href={isAbsoluteHref ? args.href : `${basePath}${args.href}`}
+              href={args.href}
               onClick={closeCmdk}
               className={clsx("text-green-300  hover:text-green-400", args.className)}
             >


### PR DESCRIPTION
## Overview

Remove basePath as Next.js Link adds it by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified link handling in the Markdown Message component, allowing all URLs to be treated uniformly.
- **Bug Fixes**
	- Resolved issues with relative URLs, which are now passed directly without conditional modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->