### PR TITLE
fix: update protocol contracts url

### DIFF
--- a/src/components/Docs/components/ContractAddresses.tsx
+++ b/src/components/Docs/components/ContractAddresses.tsx
@@ -15,8 +15,8 @@ type ContractAddressData = {
 type ContractAddressesByChain = Record<string, ContractAddressData[]>;
 
 const addressesUrl: Record<NetworkType, string> = {
-  testnet: "https://raw.githubusercontent.com/zeta-chain/protocol-contracts/main/data/addresses.testnet.json",
-  mainnet: "https://raw.githubusercontent.com/zeta-chain/protocol-contracts/main/data/addresses.mainnet.json",
+  testnet: "https://raw.githubusercontent.com/zeta-chain/protocol-contracts/main/v1/data/addresses.testnet.json",
+  mainnet: "https://raw.githubusercontent.com/zeta-chain/protocol-contracts/main/v1/data/addresses.mainnet.json",
 };
 
 const groupDataByChain = (data: ContractAddressData[]) =>

--- a/src/components/Docs/components/ZetaTokenTable.tsx
+++ b/src/components/Docs/components/ZetaTokenTable.tsx
@@ -4,8 +4,8 @@ import { LoadingTable, NetworkTypeTabs, networkTypeTabs } from "~/components/sha
 import { NetworkType } from "~/lib/app.types";
 
 const API: Record<NetworkType, string> = {
-  mainnet: "https://raw.githubusercontent.com/zeta-chain/protocol-contracts/main/data/addresses.mainnet.json",
-  testnet: "https://raw.githubusercontent.com/zeta-chain/protocol-contracts/main/data/addresses.testnet.json",
+  mainnet: "https://raw.githubusercontent.com/zeta-chain/protocol-contracts/main/v1/data/addresses.mainnet.json",
+  testnet: "https://raw.githubusercontent.com/zeta-chain/protocol-contracts/main/v1/data/addresses.testnet.json",
 };
 
 type AddressData = {


### PR DESCRIPTION
Protocol contracts have been recently moved into the `v1` directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated URLs for fetching contract addresses in both testnet and mainnet configurations to a new versioning scheme.
	- Modified API constants in the ZetaTokenTable to include versioned endpoints for improved data structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->