### PR TITLE
Remove Vercel from the check links workflow

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -25,12 +25,6 @@ jobs:
       - name: Install dependencies
         run: yarn
 
-      - name: Install Vercel CLI
-        run: npm install --global vercel@latest
-
-      - name: Pull Vercel Environment Information
-        run: vercel env pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
-
       - name: Build project
         run: EXPORT=true yarn build
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified the GitHub Actions workflow by removing Vercel CLI installation steps, streamlining the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->