### PR TITLE
Fixed withdraw gas table

### DIFF
--- a/src/components/Docs/components/Fees.tsx
+++ b/src/components/Docs/components/Fees.tsx
@@ -44,6 +44,10 @@ export const Fees: React.FC<FeesProps> = ({ type }) => {
                   url: `https://zetachain-mainnet.g.allthatnode.com/archive/evm`,
                   type: "evm",
                 },
+                {
+                  url: `https://zetachain-mainnet.g.allthatnode.com/archive/rest`,
+                  type: "cosmos-http",
+                },
               ],
             },
           },


### PR DESCRIPTION
The `getFees` toolkit function was using NodesHub API, which was down. Specified ATN endpoint, instead.

We should refactor how RPC/API endpoints are stored and used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the Fees component to support a new API endpoint for mainnet configuration, improving data retrieval for fees.
- **Bug Fixes**
	- Maintained existing functionality for sorting and rendering fees without disruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->