### PR TITLE
Update Swap tutorial with better localnet support

### DIFF
--- a/src/pages/developers/tutorials/swap-any.mdx
+++ b/src/pages/developers/tutorials/swap-any.mdx
@@ -263,7 +263,9 @@ Once your environment is set up, compile the contract and deploy it to localnet
 using the following command:
 
 ```
-yarn deploy --name SwapToAnyToken
+npx hardhat compile --force
+
+npx hardhat deploy --network localhost --name SwapToAnyToken
 ```
 
 After deployment, you should see an output similar to this:
@@ -272,42 +274,61 @@ After deployment, you should see an output similar to this:
 🔑 Using account: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 
 🚀 Successfully deployed contract on localhost.
-📜 Contract address: 0x67d269191c92Caf3cD7723F116c85e6E9bf55933
+📜 Contract address: 0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E
 ```
 
 Ensure that you provide the `systemContractAddress` and `gatewayAddress` when
 deploying the contract. For localnet, these addresses remain the same.
 
-## Swapping and Withdrawing Tokens to Connected Chain
+## Swap and Withdraw Tokens to Connected Chain
 
 To swap tokens from a connected EVM chain and withdraw them to the destination
 chain, use the following command:
 
 ```
-npx hardhat evm-deposit-and-call --network localhost --receiver 0x67d269191c92Caf3cD7723F116c85e6E9bf55933 --amount 1 --types '["address", "bytes", "bool"]' 0x9fd96203f7b22bCF72d9DCb40ff98302376cE09c 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 true
+npx hardhat swap-from-evm --network localhost --receiver 0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E --amount 1 --target 0x9fd96203f7b22bCF72d9DCb40ff98302376cE09c --recipient 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --withdraw true
 ```
 
-This command sends tokens to the `SwapToAnyToken` contract on ZetaChain and
-instructs it to withdraw the tokens to a connected chain. You’ll need to provide
-the receiver address (the contract), the amount of tokens to swap, the target
-token address on ZetaChain, the recipient address on the destination chain, and
-the `withdraw` flag set to `true`.
+- EVM gateway is called with 1 native gas token (ETH) and a message that
+  contains target ZRC-20 token address, receiver address and a boolean that
+  indicates to withdraw a token to the destination chain or not.
+- `onCrossChainCall` is called
+- If `withdraw` is:
+  - true, withdraw the ZRC-20 to the destination chain as a native token
+  - false, send target ZRC-20 to the recipient
 
-## Swapping Tokens Without Withdrawing
+In the command above the `withdraw` is `true`, so the target ZRC-20 token will
+be transferred to the destination chain.
+
+## Swap Tokens Without Withdrawing
 
 If you want to swap tokens and keep them on ZetaChain rather than withdrawing
-them, set the `withdraw` flag to `false`. This can be done using the new `swap`
-function, which allows direct interaction with the contract on ZetaChain. Use
-the following command:
+them, set the `withdraw` flag.
 
 ```
-npx hardhat swap --network localhost --contract 0x67d269191c92Caf3cD7723F116c85e6E9bf55933 --inputToken 0x91d18e54DAf4F677cB28167158d6dd21F6aB3921 --amount 1 --targetToken 0x9fd96203f7b22bCF72d9DCb40ff98302376cE09c --recipient 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --withdraw false
+npx hardhat swap-from-evm --network localhost --receiver 0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E --amount 1 --target 0x9fd96203f7b22bCF72d9DCb40ff98302376cE09c --recipient 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --withdraw false
 ```
 
-This command will perform the token swap directly on ZetaChain without
-withdrawing the tokens. You need to provide the contract address, the input
-token address, the amount to swap, the target token address, and the recipient
-address on ZetaChain.
+In the command above the `withdraw` is `true`, so the target ZRC-20 token will
+be transferred to the recipient on ZetaChain.
+
+## Swap on ZetaChain and Withdraw Tokens to Connected Chain
+
+To swap a ZRC-20 token for another ZRC-20 on ZetaChain and withdraw to a
+connected chain, run:
+
+```
+npx hardhat swap-from-zetachain --network localhost --contract 0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E --amount 1 --target 0x2ca7d64A7EFE2D62A725E2B35Cf7230D6677FfEe --recipient 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --zrc20 0x9fd96203f7b22bCF72d9DCb40ff98302376cE09c --withdraw true
+```
+
+## Swap on ZetaChain Without Withdrawing
+
+To swap a ZRC-20 token for another ZRC-20 on ZetaChain and transfer it to a
+recipient on ZetaChain, run:
+
+```
+npx hardhat swap-from-zetachain --network localhost --contract 0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E --amount 1 --target 0x2ca7d64A7EFE2D62A725E2B35Cf7230D6677FfEe --recipient 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --zrc20 0x9fd96203f7b22bCF72d9DCb40ff98302376cE09c --withdraw false
+```
 
 ## Conclusion
 

--- a/src/pages/developers/tutorials/swap-any.mdx
+++ b/src/pages/developers/tutorials/swap-any.mdx
@@ -309,7 +309,7 @@ them, set the `withdraw` flag.
 npx hardhat swap-from-evm --network localhost --receiver 0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E --amount 1 --target 0x9fd96203f7b22bCF72d9DCb40ff98302376cE09c --recipient 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --withdraw false
 ```
 
-In the command above the `withdraw` is `true`, so the target ZRC-20 token will
+In the command above the `withdraw` is `false`, so the target ZRC-20 token will
 be transferred to the recipient on ZetaChain.
 
 ## Swap on ZetaChain and Withdraw Tokens to Connected Chain

--- a/src/pages/developers/tutorials/swap.mdx
+++ b/src/pages/developers/tutorials/swap.mdx
@@ -301,7 +301,7 @@ This script deposits tokens into the gateway on a connected EVM chain and sends
 a message to the Swap contract on ZetaChain to execute the swap logic.
 
 In this command, the `--receiver` parameter is the address of the Swap contract
-on ZetaChain (`0x67d269191c92Caf3cD7723F116c85e6E9bf55933`) that will handle the
+on ZetaChain (`0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E`) that will handle the
 swap. The `--amount 1` option indicates that you want to swap 1 ETH. `--target`
 is the ZRC-20 address of the destination token (in this example, it's ZRC-20
 USDC).

--- a/src/pages/developers/tutorials/swap.mdx
+++ b/src/pages/developers/tutorials/swap.mdx
@@ -266,7 +266,9 @@ their native chain, whether it's an EVM chain or Bitcoin.
 Compile the contract and deploy it to localnet by running:
 
 ```
-yarn deploy
+npx hardhat compile --force
+
+npx hardhat deploy --network localhost
 ```
 
 You should see output similar to:
@@ -275,7 +277,7 @@ You should see output similar to:
 🔑 Using account: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 
 🚀 Successfully deployed contract on localhost.
-📜 Contract address: 0x67d269191c92Caf3cD7723F116c85e6E9bf55933
+📜 Contract address: 0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E
 ```
 
 ## Starting Localnet
@@ -289,62 +291,33 @@ npx hardhat localnet
 
 ## Swapping Gas Tokens for ERC-20 Tokens
 
-To swap gas tokens (such as ETH) for ERC-20 tokens, run the following command:
+To swap gas tokens for ERC-20 tokens, run the following command:
 
 ```
-npx hardhat evm-deposit-and-call --network localhost --receiver 0x67d269191c92Caf3cD7723F116c85e6E9bf55933 --amount 1 --types '["address", "bytes"]' 0x9fd96203f7b22bCF72d9DCb40ff98302376cE09c 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+npx hardhat swap-from-evm --network localhost --receiver 0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E --amount 1 --target 0x9fd96203f7b22bCF72d9DCb40ff98302376cE09c --recipient 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 ```
 
-This script deposits tokens into the ZetaChain gateway and sends a message to
-the Swap contract on ZetaChain to execute the swap logic.
+This script deposits tokens into the gateway on a connected EVM chain and sends
+a message to the Swap contract on ZetaChain to execute the swap logic.
 
 In this command, the `--receiver` parameter is the address of the Swap contract
 on ZetaChain (`0x67d269191c92Caf3cD7723F116c85e6E9bf55933`) that will handle the
-swap. The `--amount 1` option indicates that you want to swap 1 ETH. The
-`--types '["address", "bytes"]'` parameter defines the ABI types of the message
-parameters being sent to the `onCrossChainCall` function in the Swap contract.
-The two addresses that follow are the target ERC-20 token address on the
-destination chain (`0x9fd96203f7b22bCF72d9DCb40ff98302376cE09c`) and the
-recipient address (`0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266`) who will
-receive the swapped tokens.
+swap. The `--amount 1` option indicates that you want to swap 1 ETH. `--target`
+is the ZRC-20 address of the destination token (in this example, it's ZRC-20
+USDC).
 
 When you execute this command, the script calls the `gateway.depositAndCall`
 method on the connected EVM chain, depositing 1 ETH and sending a message to the
-Swap contract on ZetaChain. The EVM gateway processes the deposit and emits a
-`Deposited` event:
-
-```
-[EVM]: Gateway: 'Deposited' event emitted
-```
+Swap contract on ZetaChain.
 
 ZetaChain then picks up the event and executes the `onCrossChainCall` function
-of the Swap contract with the provided message. The execution log might look
-like this:
-
-```
-[ZetaChain]: Universal contract 0x67d269191c92Caf3cD7723F116c85e6E9bf55933 executing onCrossChainCall (context: {"origin":"0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0","sender":"0x735b14BB79463307AAcBED86DAf3322B1e6226aB","chainID":1}), zrc20: 0x91d18e54DAf4F677cB28167158d6dd21F6aB3921, amount: 1000000000000000000, message: 0x0000000000000000000000009fd96203f7b22bcf72d9dcb40ff98302376ce09c00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000014f39fd6e51aad88f6f4ce6ab8827279cfffb92266000000000000000000000000)
-```
-
-In this context, `origin` refers to the original sender's address, `sender` is
-the address that initiated the cross-chain call, and `chainID` identifies the
-source chain. The `zrc20` field shows the ZRC-20 representation of the deposited
-token on ZetaChain, and `amount` is the number of tokens received. The `message`
-contains the encoded parameters sent to `onCrossChainCall`.
+of the Swap contract with the provided message.
 
 The Swap contract decodes the message, identifies the target ERC-20 token and
-recipient, and initiates the swap logic. After processing, the ZetaChain gateway
-emits a `Withdrawn` event:
-
-```
-[ZetaChain]: Gateway: 'Withdrawn' event emitted
-```
+recipient, and initiates the swap logic.
 
 Finally, the EVM chain receives the withdrawal request, and the swapped ERC-20
 tokens are transferred to the recipient's address:
-
-```
-[EVM]: Transferred 1.013466046281196713 ERC-20 tokens from Custody to 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
-```
 
 ### Swapping ERC-20 Tokens for Gas Tokens
 
@@ -352,7 +325,7 @@ To swap ERC-20 tokens for gas tokens, adjust the command by specifying the
 ERC-20 token you're swapping from using the `--erc20` parameter:
 
 ```
-npx hardhat evm-deposit-and-call --network localhost --receiver 0x67d269191c92Caf3cD7723F116c85e6E9bf55933 --amount 1 --erc20 0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82 --types '["address", "bytes"]' 0x91d18e54DAf4F677cB28167158d6dd21F6aB3921 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+npx hardhat swap-from-evm --network localhost --receiver 0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E --amount 1 --target 0x2ca7d64A7EFE2D62A725E2B35Cf7230D6677FfEe --recipient 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --erc20 0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82
 ```
 
 Here, the `--erc20` option specifies the ERC-20 token address you're swapping
@@ -361,34 +334,16 @@ other parameters remain the same as in the previous command.
 
 When you run the command, the script calls the `gateway.depositAndCall` method
 with the specified ERC-20 token and amount, sending a message to the Swap
-contract on ZetaChain. The EVM gateway processes the deposit of the ERC-20
-tokens and emits a `Deposited` event:
-
-```
-[EVM]: Gateway: 'Deposited' event emitted
-```
+contract on ZetaChain.
 
 ZetaChain picks up the event and executes the `onCrossChainCall` function of the
 Swap contract:
 
-```
-[ZetaChain]: Universal contract 0x67d269191c92Caf3cD7723F116c85e6E9bf55933 executing onCrossChainCall (context: {"origin":"0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0","sender":"0x735b14BB79463307AAcBED86DAf3322B1e6226aB","chainID":1}), zrc20: 0x9fd96203f7b22bCF72d9DCb40ff98302376cE09c, amount: 1000000000000000000, message: 0x00000000000000000000000091d18e54daf4f677cb28167158d6dd21f6ab392100000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000014f39fd6e51aad88f6f4ce6ab8827279cfffb92266000000000000000000000000)
-```
-
 The Swap contract decodes the message, identifies the target gas token and
-recipient, and initiates the swap logic. After processing, the ZetaChain gateway
-emits a `Withdrawn` event:
-
-```
-[ZetaChain]: Gateway: 'Withdrawn' event emitted
-```
+recipient, and initiates the swap logic.
 
 The EVM chain then receives the withdrawal request, and the swapped gas tokens
-are transferred to the recipient's address:
-
-```
-[EVM]: Transferred 0.974604535974342599 native gas tokens from TSS to 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
-```
+are transferred to the recipient's address.
 
 ## Conclusion
 


### PR DESCRIPTION
Updated example commands to match the updated Swap example.

Depends on https://github.com/zeta-chain/example-contracts/pull/203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced tutorials for the `SwapToAnyToken` and cross-chain swap contracts, allowing users to swap tokens with options for withdrawal or retention on ZetaChain.
	- Introduced a new public `swap` function for direct interactions on ZetaChain.

- **Documentation**
	- Updated deployment instructions and tutorial content for clarity on token swaps, gas fee management, and cross-chain functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->