### PR TITLE
Fix ZetaDocs logo alignment

### DIFF
--- a/src/components/shared/components/Layout/components/NavigationLayout.tsx
+++ b/src/components/shared/components/Layout/components/NavigationLayout.tsx
@@ -65,7 +65,7 @@ export const NavigationLayout: React.FC<NavigationLayoutProps> = ({ isMainPage, 
             }`,
           }}
         >
-          <div className="hidden sm:flex items-center h-[104px] py-6 pl-4 sm:pl-6">
+          <div className="hidden sm:flex items-center h-[104px] py-6 pl-4 sm:pl-6 shrink-0">
             <Link href="/">
               <IconZetaDocsLogo className="text-green-700 dark:text-grey-50" />
             </Link>


### PR DESCRIPTION
Align ZetaDocs logo with Search bar:

![Screenshot 2024-10-25 at 18 25 53](https://github.com/user-attachments/assets/f514c52e-b7b5-43ae-abc6-de6768cb0f9a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved layout behavior of the logo in the navigation drawer to ensure it maintains its size when the drawer is resized.

- **Style**
	- Enhanced CSS styling for better layout management in the `NavigationLayout` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->