### PR TITLE
Add -p on mkdir command

### DIFF
--- a/src/pages/nodes/start-here/setup.mdx
+++ b/src/pages/nodes/start-here/setup.mdx
@@ -166,6 +166,7 @@ This is needed to store ZetaChain binary and configuration files.
 ```bash
 sudo su zetachain
 mkdir -p /home/zetachain/.zetacored/config
+mkdir -p /home/zetachain/.zetacored/data
 ```
 
 ### Configure a Systemd Unit File

--- a/src/pages/nodes/start-here/setup.mdx
+++ b/src/pages/nodes/start-here/setup.mdx
@@ -165,7 +165,7 @@ This is needed to store ZetaChain binary and configuration files.
 
 ```bash
 sudo su zetachain
-mkdir /home/zetachain/.zetacored/config
+mkdir -p /home/zetachain/.zetacored/config
 ```
 
 ### Configure a Systemd Unit File


### PR DESCRIPTION
Without it, user will get:

```
mkdir: cannot create directory ‘/home/zetachain/.zetacored/config’: No such file or directory
```

as this user is new and doesn't have the `.zetacored` directory yet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced clarity and detail in the setup instructions for ZetaChain Mainnet and Testnet nodes.
	- Added specific URLs for configuration files to streamline the setup process.

- **Documentation**
	- Improved readability with a table format for chain IDs.
	- Clarified directives for modifying configuration files and setting up Cosmovisor.
	- Expanded guidance on creating a non-root user for running the binary and monitoring node resources. 

These updates aim to provide users with a more intuitive and user-friendly experience while setting up their nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->