### PR TITLE
Added SocialScan Explorer link

### DIFF
--- a/src/pages/reference/apps/services.mdx
+++ b/src/pages/reference/apps/services.mdx
@@ -19,6 +19,7 @@ developers.
 | Subgraph            | Goldsky          | https://goldsky.com/                       |
 | Subgraph            | Envio            | https://envio.dev/                         |
 | Explorer            | Blockscout       | https://zetachain-athens-3.blockscout.com/ |
+| Explorer            | SocialScan       | https://zetachain.socialscan.io            |
 | Explorer            | Explorer Guru    | https://zetachain.explorers.guru/          |
 | Explorer            | Exploreme        | https://zetachain.exploreme.pro/           |
 | Explorer            | Ping.Pub         | https://ping.pub/zetachain                 |


### PR DESCRIPTION
Added SocialScan Explorer to the Zetachain docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added "SocialScan" as a new ZetaChain-compatible service in the reference documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->