### PR TITLE
docs/node: Switch Archive Snapshots to new Multipart ones

### DIFF
--- a/src/components/Docs/components/NodeSnapshots.tsx
+++ b/src/components/Docs/components/NodeSnapshots.tsx
@@ -6,7 +6,6 @@ import { LoadingTable, NetworkTypeTabs, networkTypeTabs, IconLink } from "~/comp
 
 import { CopyToClipboard } from "../../shared/components/CodeBlock/components/CopyToClipboard";
 
-
 interface NodeSnapshotsProps {
   apiUrl: string;
 }
@@ -125,50 +124,44 @@ const NodeSnapshots: React.FC<NodeSnapshotsProps> = ({ apiUrl }) => {
                   <td>{formatDate(snapshot.creationDate)}</td>
 
                   <td>
-                    {
-                    snapshot.size
+                    {snapshot.size
                       ? snapshot.size >= 1024 ** 4
-                      ? (snapshot.size / (1024 ** 4)).toFixed(1) + "TB"
-                      : (snapshot.size / (1024 ** 3)).toFixed(1) + "GB"
-                      : ""
-                    }
+                        ? (snapshot.size / 1024 ** 4).toFixed(1) + "TB"
+                        : (snapshot.size / 1024 ** 3).toFixed(1) + "GB"
+                      : ""}
                   </td>
-                    <td>
-                  {snapshot.link ? (
-                    <a href={snapshot.link} target="_blank" rel="noopener noreferrer">
-                      <button>Download</button>
-                    </a>
-                  ) : snapshot.links ? (
-                    <div>
-                      <button
-                        onClick={() => setDropdownOpen(dropdownOpen === index ? null : index)}
-                        className="hover:text-[rgb(176,255,97,0.8)]"
-                      >
-                        {dropdownOpen === index ? "Hide Parts" : "Show Parts"}
-                      </button>
-                      {dropdownOpen === index && (
-                        <div className="mt-2">
-                          <ul>
-                            {snapshot.links.map((link: string, linkIndex: number) => (
-                              <li key={linkIndex} className="mt-1">
-                                <a href={link} target="_blank" rel="noopener noreferrer">
-                                  Part {linkIndex + 1}
-                                </a>
-                              </li>
-                            ))}
-                          </ul>
-                          <div className="mt-2 flex items-center gap-4">
-                            <p>Script</p>
-                            <CopyToClipboard
-                              getValue={() =>
-                                snapshot.instructions || "No instructions available"
-                              }
-                            />
+                  <td>
+                    {snapshot.link ? (
+                      <a href={snapshot.link} target="_blank" rel="noopener noreferrer">
+                        <button>Download</button>
+                      </a>
+                    ) : snapshot.links ? (
+                      <div>
+                        <button
+                          onClick={() => setDropdownOpen(dropdownOpen === index ? null : index)}
+                          className="hover:text-[rgb(176,255,97,0.8)]"
+                        >
+                          {dropdownOpen === index ? "Hide Parts" : "Show Parts"}
+                        </button>
+                        {dropdownOpen === index && (
+                          <div className="mt-2">
+                            <ul>
+                              {snapshot.links.map((link: string, linkIndex: number) => (
+                                <li key={linkIndex} className="mt-1">
+                                  <a href={link} target="_blank" rel="noopener noreferrer">
+                                    Part {linkIndex + 1}
+                                  </a>
+                                </li>
+                              ))}
+                            </ul>
+                            <div className="mt-2 flex items-center gap-4">
+                              <p>Script</p>
+                              <CopyToClipboard getValue={() => snapshot.instructions || "No instructions available"} />
+                            </div>
                           </div>
-                        </div>
-                      )}
-                    </div>
-                  ) : null}
+                        )}
+                      </div>
+                    ) : null}
                   </td>
                   <td>
                     <a

--- a/src/components/Docs/components/NodeSnapshots.tsx
+++ b/src/components/Docs/components/NodeSnapshots.tsx
@@ -2,7 +2,7 @@ import axios from "axios";
 import { format } from "date-fns";
 import React, { useEffect, useMemo, useState } from "react";
 
-import { LoadingTable, NetworkTypeTabs, networkTypeTabs, IconLink } from "~/components/shared";
+import { IconLink, LoadingTable, NetworkTypeTabs, networkTypeTabs } from "~/components/shared";
 
 import { CopyToClipboard } from "../../shared/components/CodeBlock/components/CopyToClipboard";
 

--- a/src/pages/nodes/start-here/syncing.mdx
+++ b/src/pages/nodes/start-here/syncing.mdx
@@ -19,16 +19,16 @@ inside `~/.zetacored` directory.
 <NodeSnapshots apiUrl="https://snapshots.rpc.zetachain.com" />
 
 <Alert variant="warning">
-Our **archive snapshots** are now available in a **multipart** format.
-You can download each part individually by clicking **"Show Parts"** and selecting the desired one.
-Alternatively, you can streamline the process by copying the provided **POSIX download script**.
-This script automates **downloading, packing, and extracting** the full snapshot. Simply click the **"Copy to Clipboard"**
-icon below the parts list to copy the one-liner command and run it on a terminal.
+  Our **archive snapshots** are now available in a **multipart** format. You can download each part individually by
+  clicking **"Show Parts"** and selecting the desired one. Alternatively, you can streamline the process by copying the
+  provided **POSIX download script**. This script automates **downloading, packing, and extracting** the full snapshot.
+  Simply click the **"Copy to Clipboard"** icon below the parts list to copy the one-liner command and run it on a
+  terminal.
 </Alert>
 
 <Alert variant="warning">
-  Snaphhots database backend is **pebbledb**. Ensure that your node is configured to
-  use the same backend to utilize our snapshots.
+  Snaphhots database backend is **pebbledb**. Ensure that your node is configured to use the same backend to utilize our
+  snapshots.
 </Alert>
 
 #### Alternative snapshots

--- a/src/pages/nodes/start-here/syncing.mdx
+++ b/src/pages/nodes/start-here/syncing.mdx
@@ -20,9 +20,10 @@ inside `~/.zetacored` directory.
 
 <Alert variant="warning">
 Our **archive snapshots** are now available in a **multipart** format.
-You can download each part individually by clicking **"Show Parts"** and selecting the desired links.
+You can download each part individually by clicking **"Show Parts"** and selecting the desired one.
 Alternatively, you can streamline the process by copying the provided **POSIX download script**.
-This script automates **downloading, unpacking, and extracting** the full snapshot. Simply click the **"Copy to Clipboard"** icon below the parts list to get started.
+This script automates **downloading, packing, and extracting** the full snapshot. Simply click the **"Copy to Clipboard"**
+icon below the parts list to copy the one-liner command and run it on a terminal.
 </Alert>
 
 <Alert variant="warning">

--- a/src/pages/nodes/start-here/syncing.mdx
+++ b/src/pages/nodes/start-here/syncing.mdx
@@ -19,7 +19,14 @@ inside `~/.zetacored` directory.
 <NodeSnapshots apiUrl="https://snapshots.rpc.zetachain.com" />
 
 <Alert variant="warning">
-  Note: Our nodes database backend is `pebbledb`. Ensure that your node is configured to
+Our **archive snapshots** are now available in a **multipart** format.
+You can download each part individually by clicking **"Show Parts"** and selecting the desired links.
+Alternatively, you can streamline the process by copying the provided **POSIX download script**.
+This script automates **downloading, unpacking, and extracting** the full snapshot. Simply click the **"Copy to Clipboard"** icon below the parts list to get started.
+</Alert>
+
+<Alert variant="warning">
+  Snaphhots database backend is **pebbledb**. Ensure that your node is configured to
   use the same backend to utilize our snapshots.
 </Alert>
 

--- a/src/pages/nodes/start-here/syncing.mdx
+++ b/src/pages/nodes/start-here/syncing.mdx
@@ -27,7 +27,7 @@ inside `~/.zetacored` directory.
 </Alert>
 
 <Alert variant="warning">
-  Snaphhots database backend is **pebbledb**. Ensure that your node is configured to use the same backend to utilize our
+  Snapshots database backend is **pebbledb**. Ensure that your node is configured to use the same backend to utilize our
   snapshots.
 </Alert>
 


### PR DESCRIPTION
We have transitioned to a Multipart Archive schema to address static storage limitations.

The syncing page has been refactored to support and display these new multipart archive snapshots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced `NodeSnapshots` component with new functionality for displaying snapshot sizes and links.
	- Introduced multipart archive snapshots with options for individual downloads and automated scripts.

- **Documentation**
	- Updated "Syncing a Node" document to clarify the availability of multipart archive snapshots and instructions for downloading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->