### PR TITLE
Reduce restart timer for cosmovisor

### DIFF
--- a/src/pages/nodes/start-here/setup.mdx
+++ b/src/pages/nodes/start-here/setup.mdx
@@ -194,7 +194,7 @@ Environment="CLIENT_START_PROCESS=false"
 Environment="UNSAFE_SKIP_BACKUP=true"
 Type=simple
 Restart=always
-RestartSec=600
+RestartSec=10
 User=zetachain
 LimitNOFILE=262144
 ExecStart=cosmovisor run start --home /home/zetachain/.zetacored/ --log_format json  --moniker <YOUR_NODE_NAME_HERE>


### PR DESCRIPTION
A validator partner asked us to update this because to long of a restart timer can cause validators who used our official documentation to miss the upgrade height. I thought cosmovisor completed the upgrade automatically and the restart timer didn't matter but just in case we can decrease this. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved service recovery time by reducing the restart delay from 600 seconds to 10 seconds.
  
- **Documentation**
	- Updated setup instructions for ZetaChain node configuration, ensuring clarity on service behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->