### PR TITLE
fix: Contract addresses

### DIFF
--- a/src/components/Docs/components/ContractAddresses.tsx
+++ b/src/components/Docs/components/ContractAddresses.tsx
@@ -15,8 +15,8 @@ type ContractAddressData = {
 type ContractAddressesByChain = Record<string, ContractAddressData[]>;
 
 const addressesUrl: Record<NetworkType, string> = {
-  testnet: "https://raw.githubusercontent.com/zeta-chain/protocol-contracts/main/v2/data/addresses.testnet.json",
-  mainnet: "https://raw.githubusercontent.com/zeta-chain/protocol-contracts/main/v2/data/addresses.mainnet.json",
+  testnet: "https://raw.githubusercontent.com/zeta-chain/protocol-contracts/main/data/addresses.testnet.json",
+  mainnet: "https://raw.githubusercontent.com/zeta-chain/protocol-contracts/main/data/addresses.mainnet.json",
 };
 
 const groupDataByChain = (data: ContractAddressData[]) =>


### PR DESCRIPTION
The contracts page fetches addresses dynamically from Github, and earlier today we've moved things around in the protocol contracts repo: https://github.com/zeta-chain/protocol-contracts/pull/449

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated contract address URLs to correctly fetch data from the appropriate endpoints for both testnet and mainnet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->