### PR TITLE
Google Cloud Web3 Faucet

### DIFF
--- a/src/pages/reference/apps/get-testnet-zeta.mdx
+++ b/src/pages/reference/apps/get-testnet-zeta.mdx
@@ -50,7 +50,7 @@ testnet), you can use the other faucets listed below.
 
 ### Using the Google Cloud Web3 Faucet
 
-https://cloud.google.com/application/web3/faucet
+https://cloud.google.com/application/web3/faucet/zetachain/testnet
 
 Google Cloud Web3 Faucet allows you to quickly receive testnet tokens directly
 in your ZetaChain wallet. Simply choose ZetaChain as the network, enter your

--- a/src/pages/reference/apps/get-testnet-zeta.mdx
+++ b/src/pages/reference/apps/get-testnet-zeta.mdx
@@ -48,6 +48,16 @@ use the built-in `send-zeta` command.
 If you need gas assets on connected chains (like Bitcoin, Sepolia, Mumbai or BSC
 testnet), you can use the other faucets listed below.
 
+### Using the Google Cloud Web3 Faucet
+
+https://cloud.google.com/application/web3/faucet
+
+Google Cloud Web3 Faucet allows you to quickly receive testnet tokens directly
+in your ZetaChain wallet. Simply choose ZetaChain as the network, enter your
+wallet address, and the faucet will automatically send a small amount of tokens
+to your account. Note that to ensure fair distribution, there is a rate limit
+per Google account and wallet address.
+
 ### Swapping Native Gas Assets for ZETA
 
 If you already have some native gas assets on the respective testnet networks,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added a new section detailing how to obtain testnet tokens for your ZetaChain wallet via the Google Cloud Web3 Faucet.
	- Provides a direct link to the faucet and outlines usage limits per Google account and wallet address.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->