### PR TITLE
Update BTC faucet URLs to testnet 4

### DIFF
--- a/src/pages/reference/apps/get-testnet-zeta.mdx
+++ b/src/pages/reference/apps/get-testnet-zeta.mdx
@@ -106,6 +106,7 @@ with, you can try the following faucets:
 - [Polygon Faucet](https://faucet.polygon.technology/) (Polygon Mumbai)
 - [Binance Smart Chain Faucet](https://testnet.binance.org/faucet-smart) (BSC
   Testnet)
-- [coinfaucet](https://coinfaucet.eu/en/btc-testnet/) (Testnet BTC)
-- [testnet-faucet](https://testnet-faucet.com/btc-testnet/) (Testnet BTC)
-- [bitcoinfaucet](https://bitcoinfaucet.uo1.net/) (Testnet BTC)
+- [mempool.space](https://mempool.space/testnet4/faucet) (Testnet BTC)
+- [testnet4.dev](https://faucet.testnet4.dev/) (Testnet BTC)
+- [triangleplatform.com](https://faucet.triangleplatform.com/bitcoin/testnet)
+  (Testnet BTC)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Revised the guide for obtaining Testnet BTC by adding three updated faucet links (mempool.space, testnet4.dev, and triangleplatform.com) and removing the outdated ones, ensuring users have access to current and reliable resource options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->