### PR TITLE
Fixing pages related to group admins

### DIFF
--- a/src/pages/developers/architecture/privileged.mdx
+++ b/src/pages/developers/architecture/privileged.mdx
@@ -19,14 +19,14 @@ policy account has an admin, an address and a decision policy (threshold of
 votes, voting period, etc.).
 
 The group mechanism on ZetaChain is powered by the [`group` Cosmos SDK
-module](https://docs.cosmos.network/v0.46/modules/group/).
+module](https://docs.cosmos.network/v0.50/modules/group/).
 
 ZetaChain can have any number of groups. Anyone can create a group. In this
 document we only consider policy accounts that give authorization to perform
 privileged actions.
 
 These "special" policy accounts are defined in the [params of of the observer
-module](https://zetachain-athens.blockpi.network/lcd/v1/public/zeta-chain/observer/params).
+module](https://zetachain-athens.blockpi.network/lcd/v1/public/zeta-chain/authority/policies).
 These policy accounts are set during genesis and as any module parameter they
 can be changed through governance. This is important, because even though the
 protocol has a notion of admins and privileged policy accounts, they are chosen
@@ -40,11 +40,11 @@ module documentation and look for "Authorized" notice next to each message.
 
 <Alert variant="note">
   {" "}
-  Notice that policy accounts below are called "Group1" and "Group2". These are just names that indicate the level of permissions
-  and are not related to the actual groups associated with policy accounts. As you can see in testnet there are two entries
-  ("Group1" and "Group2") and both point to the same policy account. This means that right now even though there are two
-  levels of permissions ("Group1" and "Group2") there is only one policy account that is authorized to perform privileged
-  actions. On mainnet this might change.{" "}
+  Notice that policy accounts below are called "groupEmergency", "groupOperational", "groupAdmin". These are just names that indicate the level of 
+  permissions and are not related to the actual groups associated with policy accounts. As you can see in testnet there are three entries
+  that both point to the same policy account. This means that right now even though there are three
+  levels of permissions ("groupEmergency", "groupOperational", "groupAdmin") there is only one policy account that is authorized to perform   
+  privileged actions. {" "}
 </Alert>
 
 <AdminPolicy />

--- a/src/pages/developers/architecture/privileged.mdx
+++ b/src/pages/developers/architecture/privileged.mdx
@@ -35,8 +35,7 @@ members of a group become malicious, the community can create a new group with
 new admin and members and use the parameter change governance proposal to point
 the parameter of the observer module to the new policy accounts.
 
-To learn which policy accounts can send which privileged messages, check the
-module documentation and look for "Authorized" notice next to each message.
+To learn which policy accounts can send which privileged messages, query the [zeta-chain/authority/authorizations](https://zetachain-athens.blockpi.network/lcd/v1/public/zeta-chain/authority/authorizations) endpoint. 
 
 <Alert variant="note">
   {" "}

--- a/src/pages/developers/architecture/privileged.mdx
+++ b/src/pages/developers/architecture/privileged.mdx
@@ -25,7 +25,7 @@ ZetaChain can have any number of groups. Anyone can create a group. In this
 document we only consider policy accounts that give authorization to perform
 privileged actions.
 
-These "special" policy accounts are defined in the [params of of the observer
+These "special" policy accounts are defined in the [params of the observer
 module](https://zetachain-athens.blockpi.network/lcd/v1/public/zeta-chain/authority/policies).
 These policy accounts are set during genesis and as any module parameter they
 can be changed through governance. This is important, because even though the


### PR DESCRIPTION
Fixing changes related the the group admins making it clear what they are and how they work. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Revised policy account descriptions with clear naming conventions (groupEmergency, groupOperational, and groupAdmin) to reflect distinct permission levels.
  - Updated module version details and guidance links to ensure current references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->