### PR TITLE
Update Pyth description. 

### DIFF
--- a/src/pages/developers/services/pyth.mdx
+++ b/src/pages/developers/services/pyth.mdx
@@ -8,7 +8,7 @@ import { Alert } from "~/components/shared";
 
 [Pyth Network](https://docs.pyth.network/) is a price oracle that provides a
 high-frequency, low-latency price feed for a wide range of assets. It is comparable to 
-and compeitive withChainlink. It is designed to be used by high-frequency trading 
+and competitive with Chainlink. It is designed to be used by high-frequency trading 
 systems and otherapplications that require a high degree of accuracy and reliability.
 
 Pyth is deployed on ZetaChain and provides price feeds for a wide range of

--- a/src/pages/developers/services/pyth.mdx
+++ b/src/pages/developers/services/pyth.mdx
@@ -9,7 +9,7 @@ import { Alert } from "~/components/shared";
 [Pyth Network](https://docs.pyth.network/) is a price oracle that provides a
 high-frequency, low-latency price feed for a wide range of assets. It is comparable to 
 and competitive with Chainlink. It is designed to be used by high-frequency trading 
-systems and otherapplications that require a high degree of accuracy and reliability.
+systems and other applications that require a high degree of accuracy and reliability.
 
 Pyth is deployed on ZetaChain and provides price feeds for a wide range of
 assets, including cryptocurrencies, fiat currencies, and equity.

--- a/src/pages/developers/services/pyth.mdx
+++ b/src/pages/developers/services/pyth.mdx
@@ -7,9 +7,9 @@ import { Alert } from "~/components/shared";
 ## Overview
 
 [Pyth Network](https://docs.pyth.network/) is a price oracle that provides a
-high-frequency, low-latency price feed for a wide range of assets. Similiar to
-ChainLink. It is designed to be used by high-frequency trading systems and other
-applications that require a high degree of accuracy and reliability.
+high-frequency, low-latency price feed for a wide range of assets. It is comparable to 
+and compeitive withChainlink. It is designed to be used by high-frequency trading 
+systems and otherapplications that require a high degree of accuracy and reliability.
 
 Pyth is deployed on ZetaChain and provides price feeds for a wide range of
 assets, including cryptocurrencies, fiat currencies, and equity.

--- a/src/pages/developers/services/pyth.mdx
+++ b/src/pages/developers/services/pyth.mdx
@@ -7,9 +7,9 @@ import { Alert } from "~/components/shared";
 ## Overview
 
 [Pyth Network](https://docs.pyth.network/) is a price oracle that provides a
-high-frequency, low-latency price feed for a wide range of assets. It is
-designed to be used by high-frequency trading systems and other applications
-that require a high degree of accuracy and reliability.
+high-frequency, low-latency price feed for a wide range of assets. Similiar to
+ChainLink. It is designed to be used by high-frequency trading systems and other
+applications that require a high degree of accuracy and reliability.
 
 Pyth is deployed on ZetaChain and provides price feeds for a wide range of
 assets, including cryptocurrencies, fiat currencies, and equity.


### PR DESCRIPTION
Added a reference to Chainlink on the Pyth price oracle page so if anyone searches for chainlink on our docs site they'll find Pyth as an alternative. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the overview to include a contextual comparison to ChainLink for clarity on the Pyth Network's pricing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->