### PR TITLE
Fix zetaclientd in cosmovisor config

### DIFF
--- a/src/pages/nodes/start-here/setup.mdx
+++ b/src/pages/nodes/start-here/setup.mdx
@@ -184,9 +184,6 @@ Environment="DAEMON_NAME=zetacored"
 Environment="DAEMON_ALLOW_DOWNLOAD_BINARIES=true"
 Environment="DAEMON_RESTART_AFTER_UPGRADE=true"
 Environment="DAEMON_DATA_BACKUP_DIR=/home/zetachain/.zetacored"
-Environment="CLIENT_DAEMON_NAME=zetaclientd"
-Environment="CLIENT_SKIP_UPGRADE=false"
-Environment="CLIENT_START_PROCESS=false"
 Environment="UNSAFE_SKIP_BACKUP=true"
 Type=simple
 Restart=always

--- a/src/pages/nodes/validate/validator-gcp.mdx
+++ b/src/pages/nodes/validate/validator-gcp.mdx
@@ -217,9 +217,6 @@ write_files:
    Environment="DAEMON_ALLOW_DOWNLOAD_BINARIES=true"
    Environment="DAEMON_RESTART_AFTER_UPGRADE=true"
    Environment="DAEMON_DATA_BACKUP_DIR=/var/lib/zetacored"
-   Environment="CLIENT_DAEMON_NAME=zetaclientd"
-   Environment="CLIENT_SKIP_UPGRADE=false"
-   Environment="CLIENT_START_PROCESS=false"
    Environment="UNSAFE_SKIP_BACKUP=true"
    Type=simple
    LimitNOFILE=262144


### PR DESCRIPTION
There are old zetavisor only environment variables in the cosmovisor config. Cleaning that up with this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated node and validator setup instructions to simplify service configuration by removing deprecated client options.
  - Enhanced alert messaging to emphasize safe practices for binary management during upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->