### PR TITLE
Update Feedback link to Public Issue Tracker

### DIFF
--- a/src/components/Support/components/ShareFeedbackOrDiscoveries.tsx
+++ b/src/components/Support/components/ShareFeedbackOrDiscoveries.tsx
@@ -35,7 +35,7 @@ export const ShareFeedbackOrDiscoveries = () => {
             easy and simple.
           </p>
 
-          <PrimaryLink href={globalLinks.supportEmailLink} target="_blank" icon={<IconChat />}>
+          <PrimaryLink href={globalLinks.publicIssueTracker} target="_blank" icon={<IconChat />}>
             Share your thoughts
           </PrimaryLink>
         </div>

--- a/src/constants/globalLinks.ts
+++ b/src/constants/globalLinks.ts
@@ -14,6 +14,7 @@ export const globalLinks = {
   youTubeLink: "https://www.youtube.com/@ZetaBlockchain",
   redditLink: "https://www.reddit.com/r/zetablockchain",
   supportEmailLink: "mailto:support@zetachain.com",
+  publicIssueTracker: "https://github.com/zeta-chain/issues",
   bugBountyLink: "/about/zetachain/bug-bounty",
   techAmbassadorProgramLink: "https://zetachain.deform.cc/TechAmbassadors",
   communityAmbassadorLink: "https://zealy.io/cw/zetachain/questboard",


### PR DESCRIPTION
Add link to the ZetaChain Public Issue Tracker: https://github.com/zeta-chain/issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the support feedback option so that users are now directed to a public issue tracker rather than traditional email support.
  - Introduced a dedicated, easily accessible link to the public issue tracker, streamlining the process for reporting and tracking issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->