### PR TITLE
Buttons to add ZRC-20 assets to wallet

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,7 +41,6 @@ module.exports = {
     "import/prefer-default-export": OFF,
     "simple-import-sort/imports": ERROR,
     "simple-import-sort/exports": ERROR,
-    "no-console": ["error", { allow: ["error"] }],
     "import/extensions": OFF,
     "@typescript-eslint/naming-convention": [
       ERROR,

--- a/src/components/Docs/components/ForeignCoinsTable.tsx
+++ b/src/components/Docs/components/ForeignCoinsTable.tsx
@@ -50,7 +50,7 @@ const formatString = (str: string) => {
 
 const addTokenToMetaMask = async (token: ForeignCoin & { chainName: string }) => {
   if (!window.ethereum) {
-    alert("Please install an EVM wallet like MetaMask to use this feature");
+    alert("Please install an EVM wallet like MetaMask to add tokens to your wallet");
     return;
   }
 
@@ -61,6 +61,8 @@ const addTokenToMetaMask = async (token: ForeignCoin & { chainName: string }) =>
         type: "ERC20",
         options: {
           address: token.zrc20_contract_address,
+          symbol: token.symbol,
+          decimals: token.decimals,
         },
       },
     });
@@ -172,7 +174,7 @@ export const ForeignCoinsTable = () => {
             <thead>
               <tr>
                 <th>Chain</th>
-                <th>Symbol</th>
+                <th>{isCorrectNetwork ? "Add to Wallet" : "Symbol"}</th>
                 <th>Type</th>
                 <th>ZRC-20 decimals</th>
                 <th>ZRC-20 on ZetaChain</th>
@@ -186,16 +188,11 @@ export const ForeignCoinsTable = () => {
                 // eslint-disable-next-line react/no-array-index-key
                 <tr key={index}>
                   <td>{coin.chainName}</td>
-                  <td>{coin.symbol}</td>
-                  <td>{coin.coin_type}</td>
-                  <td>{coin.decimals}</td>
-                  <td>{coin.zrc20_contract_address}</td>
-                  <td>{coin.asset}</td>
                   <td>
                     <button
                       onClick={() => addTokenToMetaMask(coin)}
-                      className={`px-3 py-1 text-sm rounded bg-[#00A5C6] dark:bg-[#B0FF61] text-white dark:text-black ${
-                        isCorrectNetwork ? "hover:opacity-80" : "opacity-25 cursor-not-allowed"
+                      className={`px-3 py-1 text-sm rounded bg-grey-200 text-grey-700 dark:bg-grey-600 text-white dark:text-grey-100 ${
+                        isCorrectNetwork ? "hover:opacity-80" : "opacity-50 cursor-not-allowed"
                       }`}
                       disabled={!isCorrectNetwork}
                       title={
@@ -204,9 +201,18 @@ export const ForeignCoinsTable = () => {
                           : undefined
                       }
                     >
-                      <b>＋</b>&nbsp;{coin.symbol}
+                      {coin.symbol}
+                      {isCorrectNetwork && (
+                        <>
+                          &nbsp;<b>＋</b>
+                        </>
+                      )}
                     </button>
                   </td>
+                  <td>{coin.coin_type}</td>
+                  <td>{coin.decimals}</td>
+                  <td>{coin.zrc20_contract_address}</td>
+                  <td>{coin.asset}</td>
                 </tr>
               ))}
             </tbody>

--- a/src/components/Docs/components/ForeignCoinsTable.tsx
+++ b/src/components/Docs/components/ForeignCoinsTable.tsx
@@ -177,7 +177,7 @@ export const ForeignCoinsTable = () => {
                 <th>ZRC-20 decimals</th>
                 <th>ZRC-20 on ZetaChain</th>
                 <th>ERC-20 on Connected Chain</th>
-                <th>Actions</th>
+                <th>Wallet</th>
               </tr>
             </thead>
 
@@ -204,7 +204,7 @@ export const ForeignCoinsTable = () => {
                           : undefined
                       }
                     >
-                      Add&nbsp;Token
+                      <b>＋</b>&nbsp;{coin.symbol}
                     </button>
                   </td>
                 </tr>

--- a/src/components/Docs/components/ForeignCoinsTable.tsx
+++ b/src/components/Docs/components/ForeignCoinsTable.tsx
@@ -194,10 +194,8 @@ export const ForeignCoinsTable = () => {
                   <td>
                     <button
                       onClick={() => addTokenToMetaMask(coin)}
-                      className={`px-3 py-1 text-sm rounded ${
-                        isCorrectNetwork
-                          ? "bg-[#00A5C6] dark:bg-[#B0FF61] text-white dark:text-black hover:opacity-80"
-                          : "text-white cursor-not-allowed"
+                      className={`px-3 py-1 text-sm rounded bg-[#00A5C6] dark:bg-[#B0FF61] text-white dark:text-black ${
+                        isCorrectNetwork ? "hover:opacity-80" : "opacity-25 cursor-not-allowed"
                       }`}
                       disabled={!isCorrectNetwork}
                       title={
@@ -206,7 +204,7 @@ export const ForeignCoinsTable = () => {
                           : undefined
                       }
                     >
-                      Add to MetaMask
+                      Add&nbsp;Token
                     </button>
                   </td>
                 </tr>

--- a/src/components/Docs/components/ZetaTokenTable.tsx
+++ b/src/components/Docs/components/ZetaTokenTable.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useMemo, useState } from "react";
 
 import { LoadingTable, NetworkTypeTabs, networkTypeTabs } from "~/components/shared";


### PR DESCRIPTION
When currently selected network matches the tokens in the table:

<img width="1728" alt="Screenshot 2025-03-25 at 10 21 18" src="https://github.com/user-attachments/assets/3d641201-3b9c-4981-9c89-8b5b5ebaeff9" />

When the network doesn't match (buttons are disabled):

<img width="1728" alt="Screenshot 2025-03-25 at 10 21 25" src="https://github.com/user-attachments/assets/547dac21-cf32-45d8-a387-42dd7955f0a0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Integrated MetaMask wallet support, enabling users to add tokens directly via a new wallet button in the coins table.
  - Enhanced network detection ensures the application automatically verifies if the user is on the correct blockchain network and updates accordingly.
  - Provided feedback alerts when wallet integration is unavailable, improving the overall token management experience.
  
- **Chores**
  - Removed restriction on console statements in the ESLint configuration, allowing for more flexible debugging. 

- **Refactor**
  - Updated `ZetaTokenTable` component to explicitly indicate client-side rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->