### PR TITLE
Remove links to whitepaper

### DIFF
--- a/src/components/About/components/WhatIsZetaChain.tsx
+++ b/src/components/About/components/WhatIsZetaChain.tsx
@@ -32,10 +32,6 @@ export const WhatIsZetaChain: React.FC = () => {
               <p className="text-sm mb-0.5 text-grey-400 dark:text-grey-300">
                 Get a closer look at ZetaChain's background and architecture
               </p>
-
-              <PrimaryLink href={globalLinks.whitepaperLink} target="_blank" className="text-sm">
-                Read the Whitepaper
-              </PrimaryLink>
             </div>
           </div>
         </div>

--- a/src/components/Home/components/HomeHero.tsx
+++ b/src/components/Home/components/HomeHero.tsx
@@ -26,10 +26,6 @@ export const HomeHero: React.FC = () => {
               any blockchain, creating a fluid crypto ecosystem from a single platform.
             </p>
           </div>
-
-          <PrimaryLink href={globalLinks.whitepaperLink} target="_blank" icon={<IconDocument />}>
-            Read the Whitepaper
-          </PrimaryLink>
         </div>
       </div>
 

--- a/src/components/shared/components/Footer.tsx
+++ b/src/components/shared/components/Footer.tsx
@@ -9,11 +9,6 @@ const links = [
     target: "_blank",
   },
   {
-    text: "Whitepaper",
-    href: globalLinks.whitepaperLink,
-    target: "_self",
-  },
-  {
     text: "Explorer",
     href: globalLinks.explorerUrl,
     target: "_blank",

--- a/src/pages/reference/learn/faq.mdx
+++ b/src/pages/reference/learn/faq.mdx
@@ -88,8 +88,7 @@ relay like LayerZero to transfer data/value across chains -- which requires full
 trust from the users in the applications and relayer + oracle -- ZetaChain
 provides a simpler and more robust trust model to transact across chains where a
 developer and user alike need only trust the network for the delivery of their
-data and value. Read more about other interoperability solutions and how they
-compare to ZetaChain in the [whitepaper](https://zetachain.com/whitepaper.pdf).
+data and value.
 
 ### Is ZetaChain a bridge? How is it different from a bridge?
 

--- a/src/pages/reference/learn/glossary.mdx
+++ b/src/pages/reference/learn/glossary.mdx
@@ -86,23 +86,21 @@ incentives to ensure economic safety
 ## TSS
 
 Threshold Signature Scheme. To avoid any single point of failure, ZetaChain uses
-state-of-the-art multi-party threshold signature scheme (TSS) (see
-[whitepaper](https://zetachain.com/whitepaper.pdf) for more details). To the
-outside world, the ZetaChain validators collectively possess a single
-ECDSA/EdDSA private key, public key, and address, and the signature signed by
-ZetaChain can be verified efficiently and natively by standard ECDSA/EdDSA
-verification procedure by the connected blockchains. Internally, the private key
-is generated without a dealer, and the private key is distributed in all the
-validators. At no time is a single entity or a minority of validators able to
-piece together the private key and sign messages on behalf of the whole network.
-The key generation and signing procedures are done by Multi-Party Computation
-(MPC) which reveal no secret of any participating node. Because ZetaChain can
-hold a TSS key and address, ZetaChain can support smart contracts that can
-manage native vaults/pools on connected chains including Bitcoin. This
-effectively adds smart contract capabilities to the Bitcoin network, and
-potentially other non-smart contract blockchains. The TSS employed by ZetaChain
-gives the performance and convenience of hot wallet with cold wallet level
-security.
+state-of-the-art multi-party threshold signature scheme (TSS). To the outside
+world, the ZetaChain validators collectively possess a single ECDSA/EdDSA
+private key, public key, and address, and the signature signed by ZetaChain can
+be verified efficiently and natively by standard ECDSA/EdDSA verification
+procedure by the connected blockchains. Internally, the private key is generated
+without a dealer, and the private key is distributed in all the validators. At
+no time is a single entity or a minority of validators able to piece together
+the private key and sign messages on behalf of the whole network. The key
+generation and signing procedures are done by Multi-Party Computation (MPC)
+which reveal no secret of any participating node. Because ZetaChain can hold a
+TSS key and address, ZetaChain can support smart contracts that can manage
+native vaults/pools on connected chains including Bitcoin. This effectively adds
+smart contract capabilities to the Bitcoin network, and potentially other
+non-smart contract blockchains. The TSS employed by ZetaChain gives the
+performance and convenience of hot wallet with cold wallet level security.
 
 ## ZRC-20
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed all references and links to the ZetaChain whitepaper from the About section, Home page, Footer, FAQ, and Glossary to streamline navigation and content.
  - Updated glossary and FAQ entries for clarity by omitting whitepaper references, with no change to core explanations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->