### PR TITLE
feat: add GitHub edit link to all docs pages

### DIFF
--- a/src/components/shared/components/Hero.tsx
+++ b/src/components/shared/components/Hero.tsx
@@ -8,8 +8,9 @@ import tw, { styled } from "twin.macro";
 import { useCurrentBreakpoint } from "~/hooks/useCurrentBreakpoint";
 import { basePath } from "~/lib/app.constants";
 import { selectDirectoriesByRoute } from "~/lib/directories/directories.selectors";
+import nextraDocsThemeConfig from "~/theme.config";
 
-import { IconTime } from "./Icons";
+import { IconGitHub, IconTime } from "./Icons";
 import { mainNavRoutes } from "./Layout";
 
 export const StyledHero = styled.div`
@@ -114,6 +115,35 @@ export const Hero: React.FC = () => {
         })}
       >
         <h1>{title}</h1>
+        {title && (
+          <div className="mt-4 mb-2">
+            <a
+              href={(() => {
+                const routePath = route;
+                let githubFilePath = routePath
+                  .replace(/^\//, "")
+                  .replace(/\[\[...(.+)\]\]/, "$1")
+                  .replace(/\[([^\]]+)\]/g, "$1")
+                  .replace(/\/index$/, "/index")
+                  .replace(/\/$/, "");
+                if (githubFilePath === "") githubFilePath = "index";
+                githubFilePath = `src/pages/${githubFilePath}.mdx`;
+                return `${nextraDocsThemeConfig.docsRepositoryBase}/edit/main/${githubFilePath}`;
+              })()}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 group"
+              style={{ textDecoration: "none" }}
+            >
+              <span className="w-9 h-9 flex items-center justify-center rounded-full border border-[#00bc8d] bg-transparent group-hover:bg-[#00bc8d]/10 transition-colors">
+                <IconGitHub className="w-5 h-5 text-[#00bc8d]" />
+              </span>
+              <span className="text-lg font-medium" style={{ color: "#00bc8d" }}>
+                Edit this doc in GitHub
+              </span>
+            </a>
+          </div>
+        )}
 
         {description && <div className="description">{description}</div>}
 


### PR DESCRIPTION
Added a Github button on all docs pages that sends the user to edit that file directly on Github.

This may encourage people to contribute in our docs, fix typos, etc.

<img width="1168" alt="Screenshot 2025-04-25 at 5 22 41 PM" src="https://github.com/user-attachments/assets/020d351d-356d-4355-ab22-3b1126a88cc6" />
