### PR TITLE
docs: remove --skip from localnet.mdx

### DIFF
--- a/src/pages/developers/tutorials/localnet.mdx
+++ b/src/pages/developers/tutorials/localnet.mdx
@@ -81,7 +81,7 @@ increasing the gas limit and adjusting chain behavior.
 Run a lean EVM-only instance of Localnet:
 
 ```bash
-npx zetachain@latest localnet start --skip sui solana ton
+npx zetachain@latest localnet start
 ```
 
 Use this when your app doesn't need Solana, Sui, or TON—startup is faster and


### PR DESCRIPTION
Remove the --skip flag which doesn't seem to exist.

Command: `npx zetachain@latest localnet start --skip sui solana ton`
Result: `error: unknown option '--skip'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the tutorial to simplify the command for starting Localnet, removing instructions for skipping specific chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->