### PR TITLE
fix: add permissions to create PRs when updating docs

### DIFF
--- a/.github/workflows/update-from-protocol-contracts-solana.yaml
+++ b/.github/workflows/update-from-protocol-contracts-solana.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/update-from-protocol-contracts-ton.yaml
+++ b/.github/workflows/update-from-protocol-contracts-ton.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/update-from-protocol-contracts.yaml
+++ b/.github/workflows/update-from-protocol-contracts.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
Seems to be working:

* https://github.com/zeta-chain/docs/pull/648
* https://github.com/zeta-chain/docs/pull/649
* https://github.com/zeta-chain/docs/pull/650