### PR TITLE
Fix inscription op codes

### DIFF
--- a/src/pages/developers/chains/bitcoin.mdx
+++ b/src/pages/developers/chains/bitcoin.mdx
@@ -66,7 +66,7 @@ Compact-encoded fields (depending on format).
 | ---------- | -------------------------------------------------------------------------------------------------- |
 | 0          | Fixed identifier: `0x5a` (ASCII `'Z'`) for ZetaChain inscriptions                                  |
 | 1          | Encoding format (lower nibble). Example: `0x00` = ABI, `0x01` = CompactShort, `0x02` = CompactLong |
-| 2          | Operation code (upper nibble). Example: `0x10` for Call = `0x02 << 4`                              |
+| 2          | Operation code (upper nibble). Example: `0x20` for Call = `0x02 << 4`                              |
 | 3          | Flags bitmask. Indicates which fields are set. Common value: `0x07` (receiver + payload + revert)  |
 
 **Fields**


### PR DESCRIPTION
Source:

https://github.com/zeta-chain/node/blob/370802ae76914667802401a88694e92e000064d8/pkg/memo/header.go#L34-L39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected the operation codes for Bitcoin Gateway inscription types in the documentation. No changes to operation descriptions or requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->