### PR TITLE
Update Swap to use Bitcoin inscriptions

### DIFF
--- a/src/pages/developers/tutorials/swap.mdx
+++ b/src/pages/developers/tutorials/swap.mdx
@@ -422,9 +422,11 @@ BTC via inscription, delivers the ZRC-20 representation of BTC to your universal
 contract on ZetaChain with the encoded payload, swaps to ZRC-20 Ethereum ETH,
 and withdraws to your address on Ethereum Sepolia:
 
+Before running the command, set `PRIVATE_KEY_BTC` to your Bitcoin private key.
+
 ```bash
 zetachain bitcoin inscription deposit-and-call \
-  --private-key $PRIVATE_KEY \
+  --private-key $PRIVATE_KEY_BTC \
   --receiver $UNIVERSAL \
   --types address bytes bool \
   --values $ZRC20_ETHEREUM_ETH $RECIPIENT true \


### PR DESCRIPTION
* Replaced Bitcoin-specific decoding section with a general message decoding section using ABI (applies to all chains)
* Added example for calling the contract from Bitcoin using ZetaChain CLI

Related example contracts PR: https://github.com/zeta-chain/example-contracts/pull/283

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tutorial to use a unified, ABI-encoded payload format for message decoding across chains.
  * Added a “Decoding the message payload” section explaining target token, recipient, and withdraw flag.
  * Introduced a “Swap from Bitcoin to Ethereum” example with step-by-step CLI guidance for a cross-chain swap.
  * Simplified narrative by removing Bitcoin-specific branching and making decoding payload-agnostic.
  * Reworked headings and reorganized content for clearer flow, placing the Bitcoin-to-Ethereum example before Localnet deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->