### PR TITLE
Move CLI entry higher in the sidebar

### DIFF
--- a/src/pages/reference/_meta.json
+++ b/src/pages/reference/_meta.json
@@ -7,6 +7,10 @@
     "title": "RPC & Contracts",
     "description": "RPC/API endpoints and protocol contract addresses"
   },
+  "cli": {
+    "title": "CLI",
+    "description": "Command line interface for building and interacting with universal apps"
+  },
   "localnet": {
     "title": "Localnet",
     "readTime": "30 min",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new top-level “CLI” section to the Reference, describing the command line interface for building and interacting with universal apps.
  * The “CLI” entry appears alongside existing sections (between “RPC & Contracts” and “Localnet”).
  * No existing reference entries were changed or removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->