### PR TITLE
Remove universal EVM from sidebar

### DIFF
--- a/src/pages/start/_meta.json
+++ b/src/pages/start/_meta.json
@@ -10,10 +10,6 @@
     "title": "Why Build on ZetaChain?",
     "description": "Chain orchestration, cross-chain native token transfers, gasless execution environment."
   },
-  "evm": {
-    "title": "Universal EVM",
-    "description": "Smart contract platform with built-in interoperability."
-  },
   "app": {
     "title": "Universal Apps",
     "description": "Apps that seamlessly interact with multiple blockchains, including Ethereum, Bitcoin, Solana, and more."


### PR DESCRIPTION
It has been moved to Build -> Universal EVM -> Overview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the “Universal EVM” entry from the Start section navigation; the page/link no longer appears in the Start menu.
  * Clarified the remaining Start categories (Index, ZetaChain, Build, App) without altering their content.
  * Maintains consistent navigation with no broken links introduced.
  * Streamlines the Start page and reduces redundancy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->