### PR TITLE
Use deploy commands instead of Forge

### DIFF
--- a/src/pages/developers/tutorials/call.mdx
+++ b/src/pages/developers/tutorials/call.mdx
@@ -277,25 +277,13 @@ RPC_BASE=https://sepolia.base.org
 ### Deploy Universal to ZetaChain testnet
 
 ```bash
-UNIVERSAL=$(forge create Universal \
-  --rpc-url $RPC_ZETACHAIN \
-  --private-key $PRIVATE_KEY \
-  --evm-version paris \
-  --broadcast \
-  --json \
-  --constructor-args $GATEWAY_ZETACHAIN | jq -r .deployedTo) && echo $UNIVERSAL
+UNIVERSAL=$(npx tsx commands deploy --private-key $PRIVATE_KEY --rpc $RPC_ZETACHAIN --gateway $GATEWAY_ZETACHAIN | jq -r .contractAddress) && echo $UNIVERSAL
 ```
 
 ### Deploy Connected to Base Sepolia
 
 ```bash
-CONNECTED=$(forge create Connected \
-  --rpc-url $RPC_BASE \
-  --private-key $PRIVATE_KEY \
-  --evm-version paris \
-  --broadcast \
-  --json \
-  --constructor-args $GATEWAY_BASE | jq -r .deployedTo) && echo $CONNECTED
+CONNECTED=$(npx tsx commands deploy --private-key $PRIVATE_KEY --rpc $RPC_BASE --gateway $GATEWAY_BASE | jq -r .contractAddress) && echo $CONNECTED
 ```
 
 ### Make a call to the Universal App

--- a/src/pages/developers/tutorials/hello.mdx
+++ b/src/pages/developers/tutorials/hello.mdx
@@ -246,7 +246,8 @@ npx zetachain evm call \
   --values hello
 ```
 
-Once the transaction is processed, you’ll see an `[ZetaChain]: Event from onCall` log in the Localnet terminal.
+Once the transaction is processed, you’ll see an `[ZetaChain]: Event from
+onCall` log in the Localnet terminal.
 
 ## Option 2: Deploy on Testnet
 
@@ -282,13 +283,7 @@ Deploy the contract to ZetaChain’s testnet using the Gateway address from the
 [Contract Addresses page](/reference/network/contracts/):
 
 ```
-UNIVERSAL=$(forge create Universal \
-  --rpc-url https://zetachain-athens-evm.blockpi.network/v1/rpc/public \
-  --private-key $PRIVATE_KEY \
-  --evm-version paris \
-  --broadcast \
-  --json \
-  --constructor-args 0x6c533f7fe93fae114d0954697069df33c9b74fd7 | jq -r .deployedTo)
+UNIVERSAL=$(npx tsx commands deploy --private-key $PRIVATE_KEY | jq -r .contractAddress) && echo $UNIVERSAL
 ```
 
 ### Call a Universal Contract from Base
@@ -345,7 +340,8 @@ https://sepolia.basescan.org/tx/0x89308870b0863c5ae48dc783059277cbcf4296b1b34341
 
 After the transaction is initiated on Base Sepolia, ZetaChain's protocol
 facilitates its cross-chain transfer and execution on the destination chain
-(ZetaChain). To monitor the status of this cross-chain transaction, the `npx zetachain query cctx` command is used, providing real-time updates on the
+(ZetaChain). To monitor the status of this cross-chain transaction, the `npx
+zetachain query cctx` command is used, providing real-time updates on the
 transaction's journey.
 
 The command for tracking is:
@@ -375,12 +371,15 @@ Key Information from the Output:
 - `84532 → 7001`: This clearly indicates the cross-chain flow, from Base Sepolia
   (chain ID 84532) to ZetaChain (chain ID 7001). The ✅ symbol signifies a
   successful outbound mining of the cross-chain transaction.
-- `OutboundMinedCCTX: 0x56f9bc09dc646b13aa713b56348e8a53ea39759146afad61e66973791b752e3b`: This is
+- `OutboundMinedCCTX:
+  0x56f9bc09dc646b13aa713b56348e8a53ea39759146afad61e66973791b752e3b`: This is
   the hash of the Cross-Chain Transaction (CCTX) on ZetaChain, representing the
   internal identifier for this specific cross-chain operation.
-- `Tx Hash: 0x89308870b0863c5ae48dc783059277cbcf4296b1b343413ac543418262a4ccbc (on chain 84532)`: This confirms the original transaction hash on the source
+- `Tx Hash: 0x89308870b0863c5ae48dc783059277cbcf4296b1b343413ac543418262a4ccbc
+  (on chain 84532)`: This confirms the original transaction hash on the source
   chain (Base Sepolia).
-- `Tx Hash: 0x34edd96c8a7b2bd9d530de0e49bb5e8625204a77b77cc79133814e1814f79ebc (on chain 7001)`: This is the transaction hash of the execution on ZetaChain,
+- `Tx Hash: 0x34edd96c8a7b2bd9d530de0e49bb5e8625204a77b77cc79133814e1814f79ebc
+  (on chain 7001)`: This is the transaction hash of the execution on ZetaChain,
   indicating that the universal application has been successfully called on the
   destination chain.
 - `Sender: 0x4955a3F38ff86ae92A914445099caa8eA2B9bA32`: The address of the
@@ -388,4 +387,5 @@ Key Information from the Output:
 - `Receiver: 0xFeb4F33d424D6685104624d985095dacab567151`: The address of the
   receiver contract on ZetaChain, which is the universal application in this
   context.
-- `Message: 0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000`
+- `Message:
+  0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000`

--- a/src/pages/developers/tutorials/swap.mdx
+++ b/src/pages/developers/tutorials/swap.mdx
@@ -279,7 +279,7 @@ semantics are assumed by the rest of the contract.
 To deploy the Swap contract to ZetaChain testnet, run the following command:
 
 ```bash
-UNIVERSAL=$(npx ts-node commands/index.ts deploy --private-key $PRIVATE_KEY | jq -r .contractAddress) && echo $UNIVERSAL
+UNIVERSAL=$(npx tsx commands deploy --private-key $PRIVATE_KEY | jq -r .contractAddress) && echo $UNIVERSAL
 ```
 
 This deploys the precompiled contract using the specified private key and


### PR DESCRIPTION
Related: https://github.com/zeta-chain/example-contracts/pull/285

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Updated tutorials (Call, Hello, Swap) to use the TSX-based deploy CLI for Localnet/Testnet, replacing previous methods.
  - Standardized deployment output parsing to use the contract address and echo it for clarity.
  - Preserved RPC and gateway usage with simplified flags.
  - Reformatted code blocks and command/output examples for readability (wrapped long lines, multi-line values).
  - Harmonized command snippets and entry points across pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->