### PR TITLE
Mention min amount withdraw for ZRC-20 SOL

### DIFF
--- a/src/pages/developers/chains/zetachain.mdx
+++ b/src/pages/developers/chains/zetachain.mdx
@@ -49,6 +49,10 @@ The receiver `bytes` should be:
 The `amount` specifies the quantity to withdraw, and `zrc20` is the ZRC-20
 address of the token being withdrawn.
 
+Note: Some connected chains enforce a minimum withdrawal amount. For example,
+withdrawing ZRC-20 SOL to Solana requires a minimum of 1,000,000 (lamports) to
+satisfy rent-exemption requirements.
+
 The `revertOptions.revertMessage` must not exceed 1024 bytes in length.
 
 You don't need to specify the destination chain since each ZRC-20 token is tied


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a note in the Withdraw ZRC-20 Tokens guide clarifying that some connected chains require a minimum withdrawal amount.
  * Included an example: withdrawing ZRC-20 SOL to Solana requires at least 1,000,000 lamports for rent-exemption.
  * Improves clarity for users initiating withdrawals across chains and helps prevent failed transactions due to insufficient amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->