### PR TITLE
fix: gateway links

### DIFF
--- a/src/components/Docs/components/ConnectedChainsList.tsx
+++ b/src/components/Docs/components/ConnectedChainsList.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useState } from "react";
-
 import Link from "next/link";
+import { useEffect, useState } from "react";
 
 import { LoadingTable, NetworkTypeTabs, networkTypeTabs, rpcByNetworkType } from "~/components/shared";
 


### PR DESCRIPTION
To test run:

```
NEXT_PUBLIC_BASE_PATH=/docs yarn dev
```

Now http://localhost:3001/docs/developers/chains/list/ should have correct links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated documentation link components to use the app’s native navigation for improved consistency and alignment with routing best practices.
  * Preserved existing link behavior (opening in a new tab) and styling to avoid user-facing changes.

* **Chores**
  * Minor internal cleanup to streamline documentation link handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->