### PR TITLE
Add a note saying not to use Uni v2 in production

### DIFF
--- a/src/pages/developers/tutorials/swap.mdx
+++ b/src/pages/developers/tutorials/swap.mdx
@@ -41,6 +41,13 @@ This approach allows users to initiate complex multi-chain operations with a
 single transaction from any supported chain, abstracting away the complexity of
 liquidity routing, gas payments, and execution across chains.
 
+> Note: This tutorial uses Uniswap v2 pools on ZetaChain. These pools are
+> primarily used by ZetaChain to swap small amounts of tokens, for example, to
+> obtain gas fees for a revert in a cross-chain transaction. They may not have
+> sufficient liquidity for larger swaps. For real-world usage, consider using
+> pools maintained by active DEXes such as [Beam](https://docs.beamdex.xyz/) or
+> [Zuno](https://docs.zunodex.xyz/), or any other DEX deployed on ZetaChain.
+
 ## Prerequisites
 
 Before you begin, make sure you've completed the following tutorials:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added cautionary notes in the swap tutorial clarifying that Uniswap v2 pools on ZetaChain are best for small swaps (e.g., covering gas fees) and may lack liquidity for larger trades.
  * Recommended alternative DEXs on ZetaChain (Beam and Zuno) for larger swaps.
  * Inserted the note in two relevant sections following the cross-chain introduction to improve visibility.
  * No functional or API changes; this update is informational only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->