### PR TITLE
chore: Replace explorer urls to bs ZetaScan

### DIFF
--- a/src/components/Docs/components/NetworkDetails.tsx
+++ b/src/components/Docs/components/NetworkDetails.tsx
@@ -15,7 +15,7 @@ const networkDetails: Record<NetworkType, NetworkData> = {
     { name: "Decimals", value: "18" },
     { name: "HD Path", value: "m/44'/60'/0'/0/0" },
     { name: "Bech32 prefix", value: "zeta" },
-    { name: "Explorer", value: "https://athens.explorer.zetachain.com" },
+    { name: "Explorer", value: "https://testnet.zetascan.com" },
     {
       name: "EVM RPC",
       value: "https://zetachain-athens-evm.blockpi.network/v1/rpc/public",
@@ -29,7 +29,7 @@ const networkDetails: Record<NetworkType, NetworkData> = {
     { name: "Decimals", value: "18" },
     { name: "HD Path", value: "m/44'/60'/0'/0/0" },
     { name: "Bech32 prefix", value: "zeta" },
-    { name: "Explorer", value: "https://explorer.zetachain.com" },
+    { name: "Explorer", value: "https://zetascan.com" },
     {
       name: "EVM RPC",
       value: "https://zetachain-evm.blockpi.network/v1/rpc/public",

--- a/src/constants/globalLinks.ts
+++ b/src/constants/globalLinks.ts
@@ -4,7 +4,7 @@ export const globalLinks = {
   telegramLink: "https://t.me/zetachainofficial",
   blogUrl: "https://zetachain.com/blog",
   marketingSiteUrl: "https://zetachain.com",
-  explorerUrl: "https://explorer.zetachain.com",
+  explorerUrl: "https://zetascan.com",
   labsLink: "https://labs.zetachain.com",
   privacyLink: "https://zetachain.com/privacy",
   termsOfUseLink: "https://zetachain.com/terms-of-use",

--- a/src/pages/about/services/goldsky.mdx
+++ b/src/pages/about/services/goldsky.mdx
@@ -124,7 +124,7 @@ npx hardhat deploy --network zeta_testnet
 
 🚀 Successfully deployed contract on ZetaChain.
 📜 Contract address: 0x9846BBdE15B857d88DDad4e00CD76962245E1b6f
-🌍 Explorer: https://athens3.explorer.zetachain.com/address/0x9846BBdE15B857d88DDad4e00CD76962245E1b6f
+🌍 Explorer: https://zetascan.com/address/0x9846BBdE15B857d88DDad4e00CD76962245E1b6f
 ```
 
 ## Setup Goldsky

--- a/src/pages/developers/evm/zrc20.mdx
+++ b/src/pages/developers/evm/zrc20.mdx
@@ -66,5 +66,4 @@ table](/developers/chains/list).
 
 Each ZRC-20 has a total cap on the number of deposited tokens that the protocol
 can accept. Any assets beyond this deposited to ZetaChain from connected chains
-will be returned to the sender. You can view the caps on the explorer
-[here](https://explorer.zetachain.com/liquidity).
+will be returned to the sender.

--- a/src/pages/nodes/validate/validator-gcp.mdx
+++ b/src/pages/nodes/validate/validator-gcp.mdx
@@ -387,7 +387,7 @@ runcmd:
 Configuring the node as a validator is currently performed manually once the
 node is up and running. **Before** deploying the validator, ensure that the node
 is fully synced by comparing the block number in the logs with the block height
-on an explorer such as [ZetaScan](https://explorer.zetachain.com/).
+on an explorer such as [ZetaScan](https://zetascan.com/).
 
 The key steps configuring the validator are:
 
@@ -486,5 +486,4 @@ sudo /var/lib/zetacored/cosmovisor/current/bin/zetacored --home /var/lib/zetacor
 
 This will prompt for the keyring passphrase set when creating the key, and ask
 you to confirm the transaction. Once the transaction succeeds the validator is
-created on chain and can be confirmed in the [ZetaChain
-Explorer](https://explorer.zetachain.com/validators).
+created on chain.

--- a/src/pages/users/cli/delegate.mdx
+++ b/src/pages/users/cli/delegate.mdx
@@ -13,10 +13,8 @@ ZetaChain is a proof of stake blockchain network. Validators are responsible for
 producing new blocks and securing the network. You can delegate your ZETA to a
 validator to participate in the network and earn rewards.
 
-You can find a list of validators on
-[ZetaScan](https://explorer.zetachain.com/validators), [Ping
-Pub](https://ping.pub/zetachain/staking), or any [other
-explorer](/about/services/).
+You can find a list of validators on [Ping Pub](https://ping.pub/zetachain/staking),
+or any [other explorer](/about/services/).
 
 Choose the validator you want to delegate to based on their commission rate,
 uptime, how much voting power they have and other factors. It is generally a


### PR DESCRIPTION
closes: #735 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Updated blockchain explorer links to zetascan.com for mainnet and testnet across the app, ensuring correct navigation.

- Documentation
  - Replaced outdated explorer URLs with ZetaScan references.
  - Removed obsolete instructions and links for viewing liquidity caps.
  - Simplified validator setup guidance by removing outdated explorer verification steps.
  - Streamlined CLI delegation guidance to reference Ping Pub and other explorers without specific outdated links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->