### PR TITLE
chore: rename to protocol-contracts-evm

### DIFF
--- a/.github/workflows/update-from-protocol-contracts.yaml
+++ b/.github/workflows/update-from-protocol-contracts.yaml
@@ -17,18 +17,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Checkout zeta-chain/protocol-contracts repository
+      - name: Checkout zeta-chain/protocol-contracts-evm repository
         uses: actions/checkout@v4
         with:
-          repository: zeta-chain/protocol-contracts
-          path: protocol-contracts
+          repository: zeta-chain/protocol-contracts-evm
+          path: protocol-contracts-evm
 
       - name: Update docs
         run: |
           mkdir -p src/pages/developers/protocol/
           rm -f src/pages/developers/protocol/evm.md
-          cp protocol-contracts/docs/index.md src/pages/developers/protocol/evm.md
-          rm -rf protocol-contracts
+          cp protocol-contracts-evm/docs/index.md src/pages/developers/protocol/evm.md
+          rm -rf protocol-contracts-evm
 
       - name: Check for changes
         id: check-changes
@@ -41,9 +41,9 @@ jobs:
         with:
           title: "docs(evm): update protocol contracts"
           body: |
-            This PR syncs the docs with protocol-contracts
+            This PR syncs the docs with protocol-contracts-evm
           commit-message: |
             "docs(evm): update protocol contracts"
           base: main
-          branch: docs/updates-from-protocol-contracts
+          branch: docs/updates-from-protocol-contracts-evm
         if: steps.check-changes.outputs.changed == 'true'

--- a/src/components/Docs/components/ContractAddresses.tsx
+++ b/src/components/Docs/components/ContractAddresses.tsx
@@ -15,8 +15,8 @@ type ContractAddressData = {
 type ContractAddressesByChain = Record<string, ContractAddressData[]>;
 
 const addressesUrl: Record<NetworkType, string> = {
-  testnet: "https://raw.githubusercontent.com/zeta-chain/protocol-contracts/main/data/addresses.testnet.json",
-  mainnet: "https://raw.githubusercontent.com/zeta-chain/protocol-contracts/main/data/addresses.mainnet.json",
+  testnet: "https://raw.githubusercontent.com/zeta-chain/protocol-contracts-evm/main/data/addresses.testnet.json",
+  mainnet: "https://raw.githubusercontent.com/zeta-chain/protocol-contracts-evm/main/data/addresses.mainnet.json",
 };
 
 const groupDataByChain = (data: ContractAddressData[]) =>

--- a/src/components/Docs/components/ZetaTokenTable.tsx
+++ b/src/components/Docs/components/ZetaTokenTable.tsx
@@ -4,8 +4,8 @@ import { LoadingTable, NetworkTypeTabs, networkTypeTabs } from "~/components/sha
 import { NetworkType } from "~/lib/app.types";
 
 const API: Record<NetworkType, string> = {
-  mainnet: "https://raw.githubusercontent.com/zeta-chain/protocol-contracts/main/data/addresses.mainnet.json",
-  testnet: "https://raw.githubusercontent.com/zeta-chain/protocol-contracts/main/data/addresses.testnet.json",
+  mainnet: "https://raw.githubusercontent.com/zeta-chain/protocol-contracts-evm/main/data/addresses.mainnet.json",
+  testnet: "https://raw.githubusercontent.com/zeta-chain/protocol-contracts-evm/main/data/addresses.testnet.json",
 };
 
 type AddressData = {

--- a/src/pages/developers/evm/zeta.mdx
+++ b/src/pages/developers/evm/zeta.mdx
@@ -13,8 +13,8 @@ user-friendly symbol for the token, and the on-chain denom is `azeta`.
 
 1 ZETA = 10¹⁸ azeta.
 
-To query for account balance you can use the Cosmos HTTP API
-[`balances` endpoint](https://zetachain-athens.blockpi.network/lcd/v1/public/cosmos/bank/v1beta1/balances/zeta19nfaqu9wr0fktyyampva98ec025kjy0phww5um):
+To query for account balance you can use the Cosmos HTTP API [`balances`
+endpoint](https://zetachain-athens.blockpi.network/lcd/v1/public/cosmos/bank/v1beta1/balances/zeta19nfaqu9wr0fktyyampva98ec025kjy0phww5um):
 
 ```json
 {
@@ -32,15 +32,15 @@ example above the balance is 10 ZETA.
 
 ## Wrapped ZETA on ZetaChain
 
-ZETA can exist on ZetaChain in a wrapped form as a
-[WETH9 token](https://github.com/zeta-chain/protocol-contracts/blob/main/contracts/zevm/WZETA.sol).
+ZETA can exist on ZetaChain in a wrapped form as a [WETH9
+token](https://github.com/zeta-chain/protocol-contracts-evm/blob/main/contracts/zevm/WZETA.sol).
 When wrapping a token (in this example, ZETA) it is locked in a smart contract
 and an equivalent amount of wrapped tokens (WZETA) is minted. The wrapped token
 is pegged 1:1 to the native token and can be redeemed for the native token at
 any time. WZETA is ERC-20 compatible, so it may be used or required by other
-dApps that are built to interface with ERC-20 tokens. WZETA is
-primarily used in internal liquidity pools on ZetaChain paired with native gas
-tokens of connected blockchains (for example, sETH/WZETA pair).
+dApps that are built to interface with ERC-20 tokens. WZETA is primarily used in
+internal liquidity pools on ZetaChain paired with native gas tokens of connected
+blockchains (for example, sETH/WZETA pair).
 
 To wrap native ZETA and turn it into WZETA, send it to or use the `deposit`
 method of the `zetaToken` [contract on ZetaChain](/reference/network/contracts).
@@ -49,7 +49,7 @@ method of the `zetaToken` [contract on ZetaChain](/reference/network/contracts).
 
 ZETA tokens on EVM-compatible connected blockchains (like Ethereum, Polygon and
 BSC) are implemented as
-[ERC-20](https://github.com/zeta-chain/protocol-contracts/blob/main/contracts/evm/Zeta.eth.sol)
+[ERC-20](https://github.com/zeta-chain/protocol-contracts-evm/blob/main/contracts/evm/Zeta.eth.sol)
 tokens. You can find the contract addresses of the `zetaToken` on a connected
 blockchain on the [contracts page](/reference/network/contracts).
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Updated data sources for contract addresses and ZETA token tables to use the protocol-contracts-evm repository on testnet and mainnet, ensuring current EVM data is displayed.
- Documentation
  - Refreshed EVM developer docs: improved formatting, updated examples, and replaced links to point to protocol-contracts-evm.
- Chores
  - Updated automation workflow to sync documentation from protocol-contracts-evm and align PR metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->