### PR TITLE
Updated docs to remove duplicated text

### DIFF
--- a/src/pages/users/zetahub/enroll-zeta-xp.mdx
+++ b/src/pages/users/zetahub/enroll-zeta-xp.mdx
@@ -39,7 +39,7 @@ On this page, you can track your XP progress and see how close you are to
 reaching the next tier.
 
 To maintain an "Active" status each week, you must meet a minimum active threshold of XP.
-threshold of XP. This requirement encourages consistent engagement and provides
+This requirement encourages consistent engagement and provides
 apps with greater confidence when designing rewards. Certain rewards may only be
 available to users who are enrolled, active, and/or have maintained a minimum
 active streak, adding an extra dimension to the XP tracking system.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified wording on Zeta XP enrollment and weekly active status: replaced explicit “minimum active threshold” reference with language emphasizing consistent engagement and developer confidence in reward design. Improves readability and reduces ambiguity without altering any behavior, requirements, or page structure. Users should find the guidance clearer when evaluating how to stay active and qualify for rewards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->