### PR TITLE
Update app.mdx, modify "Bitcoin, Solana." to "Bitcoin, Solana, TON, Sui."

### DIFF
--- a/src/pages/start/app.mdx
+++ b/src/pages/start/app.mdx
@@ -141,7 +141,7 @@ choosing), the gas fees will be covered.
   - can trigger contract calls and token transfers to connected chains
   - can automatically handle gas for cross-chain transactions
   - are fully compatible with EVM chains (like Ethereum, BNB, and Polygon),
-    Bitcoin, Solana. Support for TON and Cosmos (through IBC) and other chains
+    Bitcoin, Solana, TON, Sui. Support for Cosmos (through IBC) and other chains
     is coming soon.
 - Native gas and supported ERC-20 tokens are represented as ZRC-20 tokens. A
   ZRC-20 token can be permissionlessly withdrawn back to its original chain.


### PR DESCRIPTION
According to ZetaChain's Node update, TON and Sui are now supported, so the document has been modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the start page to list current supported chains: Bitcoin, Solana, TON, and Sui.
  * Clarified that Cosmos is supported via IBC, along with other chains.
  * Refined wording and ordering for greater accuracy and consistency.
  * Ensures users see the up-to-date network support, reducing confusion when selecting or integrating with supported chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->