### PR TITLE
fix the 'sETH.SEPOLIA' error

### DIFF
--- a/src/pages/developers/tutorials/swap.mdx
+++ b/src/pages/developers/tutorials/swap.mdx
@@ -298,7 +298,7 @@ RECIPIENT=$(cast wallet address $PRIVATE_KEY) && echo $RECIPIENT
 Query the ZRC-20 address that represents ETH from Ethereum Sepolia:
 
 ```bash
-ZRC20_ETHEREUM_ETH=$(zetachain q tokens show --symbol sETH.SEPOLIA -f zrc20) && echo $ZRC20_ETHEREUM_ETH
+ZRC20_ETHEREUM_ETH=$(zetachain q tokens show --symbol ETH.ETHSEP -f zrc20) && echo $ZRC20_ETHEREUM_ETH
 ```
 
 ## Swap from Base to Ethereum


### PR DESCRIPTION
With `sETH.SEPOLIA` in this command:

```
ZRC20_ETHEREUM_ETH=$(zetachain q tokens show --symbol sETH.SEPOLIA -f zrc20) && echo $ZRC20_ETHEREUM_ETH
```

It will encounter the following error:

```
Token with symbol 'sETH.SEPOLIA' not found
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tutorial examples to reflect current token symbol conventions for Sepolia testnet queries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->