### PR TITLE
Specify private key in the `evm deposit-and-call`  command

### DIFF
--- a/src/pages/developers/tutorials/swap.mdx
+++ b/src/pages/developers/tutorials/swap.mdx
@@ -312,6 +312,7 @@ npx zetachain evm deposit-and-call \
   --types address bytes bool \
   --receiver $UNIVERSAL \
   --values $ZRC20_ETHEREUM_ETH $RECIPIENT true
+  --private-key $PRIVATE_KEY
 ```
 
 This sends 0.001 ETH from Base Sepolia into ZetaChain. Under the hood, this


### PR DESCRIPTION
Added private key parameter to the swap command example to match the style of the other parts in the tutorial and to avoid the following error:

```
Failed to retrieve private key: Private key not found
Error during depositAndCall to EVM: Failed to retrieve private key: Private key not found
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Swap tutorial to document the `--private-key` flag for the cross-chain deposit command, enabling developers to directly provide sender credentials during cross-chain operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->