### PR TITLE
docs: add testnet token faucet instructions to deployment guide

### DIFF
--- a/src/pages/developers/tutorials/hello.mdx
+++ b/src/pages/developers/tutorials/hello.mdx
@@ -231,6 +231,18 @@ The `--json` flag outputs the wallet details in JSON format, and the `jq` query
 extracts the `private_key` field, printing it as a 64-character hexadecimal
 string.
 
+
+### Get Testnet Tokens
+
+Before you can deploy smart contracts or send transactions on the testnet, you must hold gas tokens to pay for network fees. 
+
+You will need testnet ZETA tokens for the ZetaChain testnet, as well as the appropriate gas tokens to initiate transactions on any connected chains (e.g., Base Sepolia).
+
+The official documentation provides a list of testnet faucets for these chains:
+
+* **[ZetaChain Faucet Guide](https://www.zetachain.com/docs/reference/faucet)**
+
+
 ### Deploy the Contract on ZetaChain
 
 Deploy the contract to ZetaChain’s testnet:


### PR DESCRIPTION
## Description
This PR adds a missing prerequisite step to the "Option 2: Deploy on Testnet" section.

## Changes
* Added a new `### Get Testnet Tokens` section.
* Clarifies that testnet ZETA is needed for ZetaChain, and specific gas tokens are required to initiate transactions on connected chains (e.g., Base Sepolia).
* Links to the official documentation containing the list of testnet faucets.

## Context
Users following the tutorial previously hit the deployment step without instructions on how to fund their wallets, leading to potential transaction failures due to insufficient gas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for obtaining testnet tokens, including a faucet link reference, to the deployment tutorial section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->