### PR TITLE
docs: remove Bitcoin Testnet 4 from supported networks

### DIFF
--- a/src/pages/reference/faucet.en-US.mdx
+++ b/src/pages/reference/faucet.en-US.mdx
@@ -28,7 +28,4 @@ with, you can try the following faucets:
 | [Solana](https://faucet.solana.com/)                                                    | Solana                                       |
 | [Polygon](https://faucet.polygon.technology/)                                           | Polygon                                      |
 | [Binance Smart Chain](https://testnet.binance.org/faucet-smart)                         | BSC                                          |
-| [mempool.space](https://mempool.space/testnet4/faucet)                                  | Bitcoin Testnet 4                            |
-| [testnet4.dev](https://faucet.testnet4.dev/)                                            | Bitcoin Testnet 4                            |
-| [triangleplatform.com](https://faucet.triangleplatform.com/bitcoin/testnet)             | Bitcoin Testnet 4                            |
 | [Signet](https://signetfaucet.com/)                                                     | Bitcoin Signet                               |

--- a/src/pages/reference/faucet.zh-CN.mdx
+++ b/src/pages/reference/faucet.zh-CN.mdx
@@ -22,8 +22,5 @@ ZETA 是在 ZetaChain 上部署与调用智能合约所需的代币。ZetaChain 
 | [Solana](https://faucet.solana.com/) | Solana |
 | [Polygon](https://faucet.polygon.technology/) | Polygon |
 | [Binance Smart Chain](https://testnet.binance.org/faucet-smart) | BSC |
-| [mempool.space](https://mempool.space/testnet4/faucet) | Bitcoin Testnet 4 |
-| [testnet4.dev](https://faucet.testnet4.dev/) | Bitcoin Testnet 4 |
-| [triangleplatform.com](https://faucet.triangleplatform.com/bitcoin/testnet) | Bitcoin Testnet 4 |
 | [Signet](https://signetfaucet.com/) | Bitcoin Signet |
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed three Bitcoin Testnet faucet entries (mempool.space, testnet4.dev, triangleplatform.com) from reference documentation in both English and Chinese language versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->