### PR TITLE
fix: exclude static files from i18n middleware

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,1 +1,5 @@
 export { locales as middleware } from "nextra/locales";
+
+export const config = {
+  matcher: ["/((?!data|img|fonts|favicon|api|_next/static|_next/image|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|yaml|yml|json|woff|woff2|ttf|eot|txt|xml)$).*)"],
+};


### PR DESCRIPTION
## Summary
- The Nextra locales middleware added in #764 intercepts all requests including static files in `public/`, causing the OpenAPI swagger page (`/reference/network/openapi`) and other static assets to 404
- The middleware redirects static file requests into locale routing (`x-matched-path: /en-US/404`) instead of letting Next.js serve them from `public/`
- Adds a `matcher` config to `src/middleware.js` to skip the middleware for static file paths (`data/`, `img/`, `fonts/`, `favicon/`, and common file extensions)

## Test plan
- [ ] Verify https://www.zetachain.com/docs/data/openapi.swagger.yaml returns 200 instead of 404
- [ ] Verify https://www.zetachain.com/docs/reference/network/openapi renders the Swagger UI
- [ ] Verify i18n locale switching still works on regular pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a Next.js middleware `matcher` to avoid running locale routing on static asset and API paths; main risk is inadvertently excluding a path that should still be localized.
> 
> **Overview**
> Adjusts the Nextra i18n middleware configuration by adding a `config.matcher` in `src/middleware.js` to *skip locale middleware* for static asset routes (e.g., `data/`, `img/`, `fonts/`, `favicon`, Next.js `_next/*`, `api`) and common file extensions.
> 
> This prevents requests for `public/` assets (like Swagger/OpenAPI YAML) from being redirected into locale routing and returning 404s.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 694cdbcf34cc4914601e44605dc1227f5fa6d2ac. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->