### PR TITLE
docs: add Anuma AI to services and providers

### DIFF
--- a/src/pages/about/services/_meta.en-US.json
+++ b/src/pages/about/services/_meta.en-US.json
@@ -46,5 +46,9 @@
   "onfinality": {
     "title": "OnFinality",
     "description": "Subgraph and SubQuery indexer"
+  },
+  "anuma": {
+    "title": "Anuma",
+    "description": "Privacy-focused multi-model AI chat platform"
   }
 }

--- a/src/pages/about/services/_meta.zh-CN.json
+++ b/src/pages/about/services/_meta.zh-CN.json
@@ -34,5 +34,8 @@
   },
   "onfinality": {
     "title": "OnFinality"
+  },
+  "anuma": {
+    "title": "Anuma"
   }
 }

--- a/src/pages/about/services/anuma.en-US.mdx
+++ b/src/pages/about/services/anuma.en-US.mdx
@@ -1,0 +1,26 @@
+---
+title: Anuma
+---
+
+## Overview
+
+[Anuma](https://anuma.ai/) is a privacy-focused multi-model AI chat platform
+built by the ZetaChain team. It lets users seamlessly switch between AI services
+like ChatGPT, Claude, and Gemini while maintaining encrypted, device-based
+memory. Anuma uses ERC-20 credits on ZetaChain for its usage-based pricing
+model.
+
+## Key Features
+
+- **Multi-Model Chat**: Switch between ChatGPT, Claude, Gemini, and other AI
+  providers with context continuity across conversations.
+- **Privacy-First**: End-to-end encrypted, locally-stored conversations and
+  memory that AI models can use temporarily but cannot retain.
+- **SMS / iMessage Integration**: Text AI directly from your phone without
+  installing a separate app.
+- **Cross-Device Sync**: Encrypted data syncs across your devices.
+- **ERC-20 Credits**: Pay for usage with ZetaChain-native ERC-20 tokens.
+
+## Get Started
+
+Visit [anuma.ai](https://anuma.ai/) to create an account and start chatting.

--- a/src/pages/about/services/anuma.zh-CN.mdx
+++ b/src/pages/about/services/anuma.zh-CN.mdx
@@ -1,0 +1,21 @@
+---
+title: Anuma
+---
+
+## 概述
+
+[Anuma](https://anuma.ai/) 是由 ZetaChain 团队打造的隐私优先多模型 AI 聊天平台。
+用户可在 ChatGPT、Claude、Gemini 等 AI 服务之间无缝切换，同时保持加密的设备端记忆。
+Anuma 使用 ZetaChain 上的 ERC-20 积分进行按量计费。
+
+## 主要功能
+
+- **多模型对话**：在 ChatGPT、Claude、Gemini 等提供商之间切换，上下文跨对话保持连续。
+- **隐私优先**：端到端加密，对话和记忆存储在本地设备，AI 模型仅可临时使用但无法保留。
+- **短信 / iMessage 集成**：无需安装额外应用，直接通过手机短信与 AI 对话。
+- **跨设备同步**：加密数据在多设备间同步。
+- **ERC-20 积分**：使用 ZetaChain 原生 ERC-20 代币按量付费。
+
+## 开始使用
+
+访问 [anuma.ai](https://anuma.ai/) 创建账户并开始对话。

--- a/src/pages/about/services/index.en-US.mdx
+++ b/src/pages/about/services/index.en-US.mdx
@@ -28,6 +28,7 @@ developers.
 | Oracle               | Pyth             | https://pyth.network/                                                                |
 | Data Provider        | Mobula           | https://mobula.io/                                                                   |
 | Development Platform | Tenderly         | [https://tenderly.co/](https://tenderly.co/?mtm_campaign=ext-docs&mtm_kwd=zetachain) |
+| AI                   | Anuma            | https://anuma.ai/                                                                     |
 
 Is this list missing a service for developers that supports ZetaChain? Help us
 keep this list up-to-date by [creating a pull

--- a/src/pages/about/services/index.zh-CN.mdx
+++ b/src/pages/about/services/index.zh-CN.mdx
@@ -27,6 +27,7 @@ title: 服务与提供方
 | Oracle | Pyth | https://pyth.network/ |
 | Data Provider | Mobula | https://mobula.io/ |
 | Development Platform | Tenderly | [https://tenderly.co/](https://tenderly.co/?mtm_campaign=ext-docs&mtm_kwd=zetachain) |
+| AI | Anuma | https://anuma.ai/ |
 
 如果表格缺少了支持 ZetaChain 的开发者服务，请[提交 Pull Request](https://github.com/zeta-chain/docs/blob/main/src/pages/about/services/index.mdx) 帮助我们保持最新。***
 


### PR DESCRIPTION
## Summary
- Add [Anuma](https://anuma.ai/) to the Services and Providers table under a new "AI" category
- Updated both en-US and zh-CN locales

Anuma is a privacy-focused multi-model AI chat platform built by the ZetaChain team that uses ERC-20 credits on ZetaChain.

## Test plan
- [ ] Verify services table renders correctly with the new Anuma row
- [ ] Confirm both en-US and zh-CN pages display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a single row to existing tables; no runtime or logic changes.
> 
> **Overview**
> Adds a new **AI** entry (`Anuma` with `https://anuma.ai/`) to the Services and Providers table in both `index.en-US.mdx` and `index.zh-CN.mdx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1f4491874173c622b7cb35f27b4433a7cf8a624. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Anuma as a new AI service provider to the Services & Providers directory with a direct link to its website.
  * Added a dedicated service page describing overview, key features (multi-model chat, privacy focus, SMS/iMessage, cross-device sync, ERC-20 credits) and "Get Started" instructions.
  * Localized content available in English and Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->