### PR TITLE
docs: simplify home hero to a single Anuma docs CTA

### DIFF
--- a/src/components/Home/Home.constants.tsx
+++ b/src/components/Home/Home.constants.tsx
@@ -1,5 +1,5 @@
 import { DeterministicIconArticle } from "../shared";
-import { BuildWithTheCliSvg, BuildWithUiSvg } from "./components/svg/HomeHeroSvgs";
+import { BuildWithTheCliSvg } from "./components/svg/HomeHeroSvgs";
 import { LocalnetSvg, ToolkitSvg, ZetaChainSvg } from "./components/svg/ShipFasterSvgs";
 
 export type NarrowCardLink = {
@@ -11,16 +11,10 @@ export type NarrowCardLink = {
 
 export const HERO_CARD_LINKS: NarrowCardLink[] = [
   {
-    href: "https://dashboard.anuma.ai/login",
+    href: "https://docs.anuma.ai/",
     svg: <BuildWithTheCliSvg />,
     title: "Build on Anuma",
     description: "Create your first AI app",
-  },
-  {
-    href: "https://docs.anuma.ai",
-    svg: <BuildWithUiSvg />,
-    title: "Anuma Docs",
-    description: "Learn the platform",
   },
 ];
 

--- a/src/components/Home/components/svg/HomeHeroSvgs.tsx
+++ b/src/components/Home/components/svg/HomeHeroSvgs.tsx
@@ -20,25 +20,3 @@ export const BuildWithTheCliSvg = () => {
   );
 };
 
-export const BuildWithUiSvg = () => {
-  return (
-    <svg
-      width="48"
-      height="48"
-      viewBox="0 0 48 48"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      className="w-12 h-12 shrink-0"
-    >
-      <rect width="48" height="48" rx="6" fill="#9AEA4A" />
-      <path
-        d="M30.0328 7.99951H10.6229C10.0435 7.99951 9.57373 8.46925 9.57373 9.04869V38.9503C9.57373 39.5298 10.0435 39.9995 10.6229 39.9995H37.3771C37.9566 39.9995 38.4263 39.5298 38.4263 38.9503V16.5328L30.0328 7.99951Z"
-        fill="#006579"
-      />
-      <rect x="13.7703" y="20.0654" width="20.9837" height="3.14754" fill="white" />
-      <rect x="13.7703" y="26.356" width="20.9837" height="3.14754" fill="white" />
-      <rect x="13.7703" y="32.6558" width="20.9837" height="3.14754" fill="white" />
-      <path d="M30.0327 16.5323L30.0327 7.99951L38.4262 16.5323L30.0327 16.5323Z" fill="white" />
-    </svg>
-  );
-};

--- a/src/components/Home/components/svg/HomeHeroSvgs.tsx
+++ b/src/components/Home/components/svg/HomeHeroSvgs.tsx
@@ -19,4 +19,3 @@ export const BuildWithTheCliSvg = () => {
     </svg>
   );
 };
-


### PR DESCRIPTION
## Summary
- Remove the "Anuma Docs" hero card from the home page
- Point the remaining "Build on Anuma" card at https://docs.anuma.ai/ (was dashboard.anuma.ai/login)
- Drop the now-unused `BuildWithUiSvg` icon

The single remaining card centers automatically — `HomeHero.tsx` already uses `md:justify-center` and `NarrowCardLink` caps at `md:max-w-[296px]`.

## Test plan
- [x] `yarn typecheck` passes
- [x] `yarn dev` renders home page (HTTP 200) with the single card centered
- [ ] Reviewer eyeballs the centered widget on desktop and mobile widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing copy and link targets only; no auth, API, or data-path changes.
> 
> **Overview**
> The home hero is reduced to **one** CTA: the **Build on Anuma** card now links to `https://docs.anuma.ai/` instead of the dashboard login URL.
> 
> The separate **Anuma Docs** hero card and its `BuildWithUiSvg` icon are removed as dead code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb9fbf45e4a2d96146e6355f3fe65c6bce8e6808. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the "Build on Anuma" card to link directly to the official documentation site for comprehensive guides.

* **Refactor**
  * Simplified the home hero by consolidating card options and removing a redundant UI builder card for a clearer, more focused experience.
* **Visual**
  * Replaced one hero icon with an updated CLI-themed illustration for consistent branding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->